### PR TITLE
Adding more permissive rules to the catalog configuration

### DIFF
--- a/configs/app-config.local.yaml
+++ b/configs/app-config.local.yaml
@@ -38,6 +38,10 @@ backend:
 
 # You can use local files from catalog-entities directory to load entities into the catalog
 catalog:
+
+  rules:
+    - allow: [Component, API, Location, Template, Domain, User, Group, System, Resource]
+
   locations:
     - type: file
       target: /opt/app-root/src/configs/catalog-entities/users.yaml


### PR DESCRIPTION
This change to the catalog's global rules allows more complex externally managed catalogs to be loaded and tested locally with RHDH.