### PR TITLE
Switch to plain HTTP by default

### DIFF
--- a/configs/app-config.local.yaml
+++ b/configs/app-config.local.yaml
@@ -22,11 +22,15 @@ backend:
   listen:
     port: 7007
   baseUrl: ${BASE_URL}
-  https: true
+  # uncomment this if backend.baseUrl is exposed over HTTPS
+  # and you want RHDH to auto-generate and serve a self-signed certificate.
+  # https: true
   cors:
     origin: ${BASE_URL}
     methods: [GET, HEAD, PATCH, POST, PUT, DELETE]
     credentials: true
+  csp:
+   upgrade-insecure-requests: false
 
 # comment out the following 'database' section to use the PostgreSQL database
   database:

--- a/env.sample
+++ b/env.sample
@@ -5,7 +5,7 @@ POSTGRES_PORT=5432
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 
-BASE_URL=https://localhost:7007
+BASE_URL=http://localhost:7007
 
 # configure images to use
 #RHDH_IMAGE=quay.io/janus-idp/backstage-showcase:next


### PR DESCRIPTION
This PR switches the default access protocol to HTTP, just like how Backstage would work in [dev](https://backstage.io/docs/getting-started/#2-run-the-backstage-app) mode by default. The local RHDH app would be reachable at [http://localhost:7007/](http://localhost:7007/) instead of [https://localhost:7007/](https://localhost:7007/) with a self-signed certificate.

**Notes**:
- Setting the `backend.csp.upgrade-insecure-requests` field to `false` is needed, so that the application can be loaded in a browser from a different machine.
