### PR TITLE
Add Compose file for simulating a setup with a corporate proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,25 @@ To use the official release of RHDH 1.3, set the variable as follows:
 RHDH_IMAGE=quay.io/rhdh/rhdh-hub-rhel9:1.3
 ```
 
+## Testing RHDH in a simulated corporate proxy setup
+
+If you want to test how RHDH would behave if deployed in a corporate proxy environment,
+you can run `podman-compose` or `docker-compose` by merging both the [`compose.yaml`](./compose.yaml) and [`compose-with-corporate-proxy.yaml`](./compose-with-corporate-proxy.yaml) files.
+
+Example with `podman-compose` (note that the order of the YAML files is important):
+
+```sh
+podman-compose \
+   -f compose.yaml \
+   -f compose-with-corporate-proxy.yaml \
+   up -d
+```
+
+The [`compose-with-corporate-proxy.yaml`](compose-with-corporate-proxy.yaml) file includes a specific [Squid](https://www.squid-cache.org/)-based proxy container as well as an isolated network, such that:
+
+1. only the proxy container has access to the outside
+2. all containers part of the internal network need to communicate through the proxy container to reach the outside. This can be done with the `HTTP(S)_PROXY` and `NO_PROXY` environment variables.
+
 ## Cleanup
 
 To reset RHDH Local you can use the following command. this will clean up any attached volumes, but your configuration changes will remain.

--- a/compose-with-corporate-proxy.yaml
+++ b/compose-with-corporate-proxy.yaml
@@ -1,0 +1,43 @@
+# This Compose file is not usable on its own.
+# It needs to be used alongside the default compose.yaml file,
+# since it overrides the containers defined in the latter
+# and injects a new proxy container and adds a new network.
+#
+# You can run `[podman|docker]-compose -f compose.yaml -f compose-with-corporate-proxy.yaml config`
+# to view the effective merged config.
+
+networks:
+  internal_net:
+    # Network with no outside access
+    internal: true
+  default: {}
+
+services:
+  proxy:
+    container_name: proxy
+    image: registry.redhat.io/rhel9/squid:latest
+    environment:
+      - TS=UTC
+    entrypoint: [ '/bin/bash' ]
+    command:
+      - '-c'
+      - 'tail -vn 0 -F /var/log/squid/{access,cache,error,store}.log & /usr/sbin/container-entrypoint.sh'
+    networks:
+      - internal_net
+      - default
+
+  rhdh:
+    environment:
+      - HTTP_PROXY=http://proxy:3128
+      - HTTPS_PROXY=http://proxy:3128
+      # NO_PROXY configured in the .env file, but can be overridden here
+    networks:
+      - internal_net
+
+  install-dynamic-plugins:
+    environment:
+      - HTTP_PROXY=http://proxy:3128
+      - HTTPS_PROXY=http://proxy:3128
+      # NO_PROXY configured in the .env file, but can be overridden here
+    networks:
+      - internal_net

--- a/env.sample
+++ b/env.sample
@@ -21,3 +21,17 @@ NODE_TLS_REJECT_UNAUTHORIZED=0
 SEGMENT_WRITE_KEY=gGVM6sYRK0D0ndVX22BOtS7NRcxPej8t
 # uncomment the following line to disable telemetry
 #SEGMENT_TEST_MODE=true
+
+# Backstage log level
+LOG_LEVEL=debug
+
+# Logs from global-agent to inspect the 'node-fetch' behavior with proxy settings
+ROARR_LOG=true
+
+# Logs from fetch.
+# Might be useful to inspect the 'fetch' behavior with proxy settings (handled by 'undici', not 'global-agent')
+NODE_DEBUG=fetch
+
+# NO_PROXY will take effect only if HTTP(S)_PROXY env vars are set.
+# See the compose-with-corporate-proxy.yaml file.
+NO_PROXY=localhost,127.0.0.1


### PR DESCRIPTION
## Description

This PR adds a new Compose file simulating a setup with a corporate proxy. It is meant to be used alongside the default `compose.yaml` file, since it overrides some of the containers defined there and adds a new proxy container and network.

This way, we can easily test how RHDH behaves when it is running in an environment with a corporate proxy. It should hopefully help troubleshoot such scenarios.

## Which issue(s) does this PR fix or relate to

- Relates to https://issues.redhat.com/browse/RHDHBUGS-106
- Relates to https://issues.redhat.com/browse/RHIDP-4646

## PR acceptance criteria

- [x] Tests (manually)
- [x] Documentation

## How to test changes / Special notes to the reviewer

- You can view and inspect the merged config by running:

```sh
podman-compose -f compose.yaml -f compose-with-corporate-proxy.yaml config
```

- You can try this out by running:

```sh
podman-compose -f compose.yaml -f compose-with-corporate-proxy.yaml up -d
```