### PR TITLE
fix: use /tmp/techdocs for techdocs

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -46,9 +46,6 @@ services:
         target: /opt/app-root/src/dynamic-plugins-root
         volume:
           nocopy: true
-      - type: volume
-        source: techdocs
-        target: /opt/app-root/src/techdocs
     depends_on:
       install-dynamic-plugins:
         condition: service_completed_successfully
@@ -95,4 +92,3 @@ services:
 
 volumes:
   dynamic-plugins-root:
-  techdocs:

--- a/configs/app-config.local.yaml
+++ b/configs/app-config.local.yaml
@@ -66,7 +66,7 @@ techdocs:
   generator:
     runIn: local
   builder: local
-  publisher: 
+  publisher:
     type: local
     local:
-      publishDirectory: /opt/app-root/src/techdocs
+      publishDirectory: /tmp/techdocs


### PR DESCRIPTION
the original solutions with using volume for techdocs was failing on docker because of permission issuses
```
Building a newer version of this documentation failed. Error: "EACCES: permission denied, mkdir '/opt/app-root/src/techdocs/default/system/red-hat-developer-hub'"
```