### PR TITLE
chore: Add sanity checks using both podman-compose and docker-compose [RHIDP-6155]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: test
+name: CI
 
 on:
   push:
@@ -8,16 +8,48 @@ on:
 
 jobs:
 
-  build:
-
+  lint:
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
+    - name: Lint
+      # Based on https://github.com/zavoloklom/docker-compose-linter/tree/main?tab=readme-ov-file
+      run: |
+        npx --yes dclint .
+
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        tool:
+          - docker
+          - podman
+        composeFilesCLI:
+          - ""
+          - "-f compose.yaml -f compose-debug.yaml"
+          - "-f compose.yaml -f compose-with-corporate-proxy.yaml"
+
+    name: ${{ matrix.tool }} test (composeFilesCLI="${{ matrix.composeFilesCLI }}")
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
     - name: prepare .env
       run: cp env.sample .env
-    - name: docker compose up
-      run: docker compose up -d
+
+    - name: Install tool
+      if: ${{ matrix.tool == 'podman' }}
+      env:
+        PODMAN_COMPOSE_VERSION: "v1.3.0"
+      run: |
+        curl -o /usr/local/bin/podman-compose https://raw.githubusercontent.com/containers/podman-compose/${PODMAN_COMPOSE_VERSION}/podman_compose.py
+        chmod +x /usr/local/bin/podman-compose
+
+    - name: Start app
+      run: ${{ matrix.tool }} compose ${{ matrix.composeFilesCLI }} up -d 
+
     - name: Wait for HTTP 200 response from homepage
       run: |
         max=30
@@ -27,7 +59,7 @@ jobs:
           i=$((i+1))
           if [ "$i" -ge "$max" ]; then
             echo "Max retries reached. Exiting."
-            docker compose logs
+            ${{ matrix.tool }} compose logs
             exit 1
           fi
           echo "($i/$max)Waiting for http://localhost:7007 to return HTTP 200..."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    # branches: [ "main" ]
+    branches: [ "main" ]
   pull_request:
-    # branches: [ "main" ]
+    branches: [ "main" ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CORPORATE_PROXY_IMAGE: "docker.io/ubuntu/squid:latest"
+      # To be able to call the "podman compose" wrapper using the "podman-compose" binary
+      PODMAN_COMPOSE_PROVIDER: "podman-compose"
 
     steps:
     - uses: actions/checkout@v4
@@ -49,10 +51,9 @@ jobs:
         pip3 install podman-compose=="${PODMAN_COMPOSE_VERSION}"
 
     - name: Start app
-      env:
-        # To be able to call the "podman compose" wrapper using the "podman-compose" binary
-        PODMAN_COMPOSE_PROVIDER: "podman-compose"
-      run: ${{ matrix.tool }} compose ${{ matrix.composeFilesCLI }} up -d 
+      run: |
+        ${{ matrix.tool }} compose ${{ matrix.composeFilesCLI }} up -d
+        ${{ matrix.tool }} compose ${{ matrix.composeFilesCLI }} ps
 
     - name: Wait for HTTP 200 response from homepage
       run: |
@@ -62,12 +63,21 @@ jobs:
         until curl --head --fail http://localhost:7007; do
           i=$((i+1))
           if [ "$i" -ge "$max" ]; then
-            echo "Max retries reached. Exiting."
-            ${{ matrix.tool }} compose ${{ matrix.composeFilesCLI }} logs
+            echo "Max retries reached. Exiting. Take a look at the logs in the step below."
             exit 1
           fi
           echo "($i/$max)Waiting for http://localhost:7007 to return HTTP 200..."
           sleep 5
         done
         echo "RHDH is ready!"
-        curl --insecure http://localhost:7007
+        curl -i --insecure http://localhost:7007
+
+    - name: Compose logs
+      if: always()
+      run: ${{ matrix.tool }} compose ${{ matrix.composeFilesCLI }} logs || true
+
+    - name: Tear down
+      if: always()
+      run: |
+        ${{ matrix.tool }} compose ${{ matrix.composeFilesCLI }} ps
+        ${{ matrix.tool }} compose ${{ matrix.composeFilesCLI }} down --volumes || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,6 @@ jobs:
     name: ${{ matrix.tool }} compose ${{ matrix.composeFilesCLI }}
     runs-on: ubuntu-latest
     env:
-      CORPORATE_PROXY_IMAGE: "docker.io/ubuntu/squid:latest"
       # To be able to call the "podman compose" wrapper using the "podman-compose" binary
       PODMAN_COMPOSE_PROVIDER: "podman-compose"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           - "-f compose.yaml -f compose-debug.yaml"
           - "-f compose.yaml -f compose-with-corporate-proxy.yaml"
 
-    name: ${{ matrix.tool }} ${{ matrix.composeFilesCLI }}
+    name: ${{ matrix.tool }} compose ${{ matrix.composeFilesCLI }}
     runs-on: ubuntu-latest
     env:
       CORPORATE_PROXY_IMAGE: "docker.io/ubuntu/squid:latest"
@@ -63,7 +63,7 @@ jobs:
           i=$((i+1))
           if [ "$i" -ge "$max" ]; then
             echo "Max retries reached. Exiting."
-            ${{ matrix.tool }} compose logs
+            ${{ matrix.tool }} compose ${{ matrix.composeFilesCLI }} logs
             exit 1
           fi
           echo "($i/$max)Waiting for http://localhost:7007 to return HTTP 200..."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,12 +29,15 @@ jobs:
         tool:
           - docker
           - podman
-        composeFilesCLI:
-          - ""
-          - "-f compose.yaml -f compose-debug.yaml"
-          - "-f compose.yaml -f compose-with-corporate-proxy.yaml"
+        composeConfig:
+          - name: "default"
+            cliArgs: ""
+          - name: "debug"
+            cliArgs: "-f compose.yaml -f compose-debug.yaml"
+          - name: "corporate-proxy"
+            cliArgs: "-f compose.yaml -f compose-with-corporate-proxy.yaml"
 
-    name: ${{ matrix.tool }} compose ${{ matrix.composeFilesCLI }}
+    name: "${{ matrix.tool }} compose - ${{ matrix.composeConfig.name }}"
     runs-on: ubuntu-latest
     env:
       # The default corporate proxy image is located on registry.redhat.io, which requires authentication.
@@ -57,8 +60,8 @@ jobs:
 
     - name: Start app
       run: |
-        ${{ matrix.tool }} compose ${{ matrix.composeFilesCLI }} up -d
-        ${{ matrix.tool }} compose ${{ matrix.composeFilesCLI }} ps
+        ${{ matrix.tool }} compose ${{ matrix.composeConfig.cliArgs }} up -d
+        ${{ matrix.tool }} compose ${{ matrix.composeConfig.cliArgs }} ps
 
     - name: Wait for HTTP 200 response from homepage
       run: |
@@ -79,10 +82,10 @@ jobs:
 
     - name: Compose logs
       if: always()
-      run: ${{ matrix.tool }} compose ${{ matrix.composeFilesCLI }} logs || true
+      run: ${{ matrix.tool }} compose ${{ matrix.composeConfig.cliArgs }} logs
 
     - name: Tear down
       if: always()
       run: |
-        ${{ matrix.tool }} compose ${{ matrix.composeFilesCLI }} ps
-        ${{ matrix.tool }} compose ${{ matrix.composeFilesCLI }} down --volumes || true
+        ${{ matrix.tool }} compose ${{ matrix.composeConfig.cliArgs }} ps || true
+        ${{ matrix.tool }} compose ${{ matrix.composeConfig.cliArgs }} down --volumes || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     # branches: [ "main" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true
+
 jobs:
 
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,8 @@ jobs:
     name: ${{ matrix.tool }} compose ${{ matrix.composeFilesCLI }}
     runs-on: ubuntu-latest
     env:
+      # The default corporate proxy image is located on registry.redhat.io, which requires authentication.
+      CORPORATE_PROXY_IMAGE: docker.io/ubuntu/squid:latest
       # To be able to call the "podman compose" wrapper using the "podman-compose" binary
       PODMAN_COMPOSE_PROVIDER: "podman-compose"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
+    # branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+    # branches: [ "main" ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,10 @@ jobs:
           - "-f compose.yaml -f compose-debug.yaml"
           - "-f compose.yaml -f compose-with-corporate-proxy.yaml"
 
-    name: ${{ matrix.tool }} test (composeFilesCLI="${{ matrix.composeFilesCLI }}")
+    name: ${{ matrix.tool }} ${{ matrix.composeFilesCLI }}
     runs-on: ubuntu-latest
+    env:
+      CORPORATE_PROXY_IMAGE: "docker.io/ubuntu/squid:latest"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
+    # branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+    # branches: [ "main" ]
 
 jobs:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,10 +46,12 @@ jobs:
       env:
         PODMAN_COMPOSE_VERSION: "v1.3.0"
       run: |
-        curl -o /usr/local/bin/podman-compose https://raw.githubusercontent.com/containers/podman-compose/${PODMAN_COMPOSE_VERSION}/podman_compose.py
-        chmod +x /usr/local/bin/podman-compose
+        pip3 install podman-compose=="${PODMAN_COMPOSE_VERSION}"
 
     - name: Start app
+      env:
+        # To be able to call the "podman compose" wrapper using the "podman-compose" binary
+        PODMAN_COMPOSE_PROVIDER: "podman-compose"
       run: ${{ matrix.tool }} compose ${{ matrix.composeFilesCLI }} up -d 
 
     - name: Wait for HTTP 200 response from homepage

--- a/compose-debug.yaml
+++ b/compose-debug.yaml
@@ -1,7 +1,7 @@
 services:
   rhdh:
-    ports:
+    ports: # dclint disable-line no-unbound-port-interfaces
       - "7007:7007"
-      - "9229:9229"
+      - "127.0.0.1:9229:9229"
     environment:
       NODE_OPTIONS: "--inspect=0.0.0.0:9229"

--- a/compose-with-corporate-proxy.yaml
+++ b/compose-with-corporate-proxy.yaml
@@ -19,10 +19,13 @@ services:
     image: ${CORPORATE_PROXY_IMAGE:-registry.redhat.io/rhel9/squid:9.5}
     environment:
       - TS=UTC
-    entrypoint: [ '/bin/bash' ]
-    command:
-      - '-c'
-      - 'tail -vn 0 -F /var/log/squid/{access,cache,error,store}.log & /usr/sbin/container-entrypoint.sh'
+    entrypoint: [ '/usr/local/bin/start-squid.sh' ]
+    volumes:
+      - type: bind
+        source: "./start-squid.sh"
+        target: "/usr/local/bin/start-squid.sh"
+        bind:
+          selinux: "Z"
     networks:
       - internal_net
       - default

--- a/compose-with-corporate-proxy.yaml
+++ b/compose-with-corporate-proxy.yaml
@@ -16,7 +16,7 @@ services:
   proxy:
     container_name: proxy
     # https://catalog.redhat.com/software/containers/registry/registry.access.redhat.com/repository/rhel9/squid
-    image: registry.redhat.io/rhel9/squid:9.5
+    image: ${CORPORATE_PROXY_IMAGE:-registry.redhat.io/rhel9/squid:9.5}
     environment:
       - TS=UTC
     entrypoint: [ '/bin/bash' ]

--- a/compose-with-corporate-proxy.yaml
+++ b/compose-with-corporate-proxy.yaml
@@ -16,7 +16,7 @@ services:
   proxy:
     container_name: proxy
     # https://catalog.redhat.com/software/containers/registry/registry.access.redhat.com/repository/rhel9/squid
-    image: "${CORPORATE_PROXY_IMAGE:-docker.io/ubuntu/squid:latest}"
+    image: "${CORPORATE_PROXY_IMAGE:-registry.redhat.io/rhel9/squid:latest}"
     environment:
       - TS=UTC
     networks:
@@ -31,10 +31,10 @@ services:
     networks:
       - internal_net
       # TODO(rm3l): There is a limitation with networks that have "internal: true": ports are not published with Docker, but are with Podman.
-      # So with Docker, port forwarding does not work at all from the host, because the host port is not exposed.
+      # With Docker, port forwarding does not work at all from the host, because the host port is not exposed.
       # See https://github.com/moby/moby/issues/36174
       # As a workaround, we are adding it to the default network,
-      # but note that there is nothing preventing requests from bypassing the proxy to reach the outside.
+      # but note that there is as such nothing preventing requests from bypassing the proxy to reach the outside.
       - default
 
   install-dynamic-plugins:

--- a/compose-with-corporate-proxy.yaml
+++ b/compose-with-corporate-proxy.yaml
@@ -15,7 +15,8 @@ networks:
 services:
   proxy:
     container_name: proxy
-    image: registry.redhat.io/rhel9/squid:latest
+    # https://catalog.redhat.com/software/containers/registry/registry.access.redhat.com/repository/rhel9/squid
+    image: registry.redhat.io/rhel9/squid:9.5
     environment:
       - TS=UTC
     entrypoint: [ '/bin/bash' ]

--- a/compose-with-corporate-proxy.yaml
+++ b/compose-with-corporate-proxy.yaml
@@ -16,16 +16,9 @@ services:
   proxy:
     container_name: proxy
     # https://catalog.redhat.com/software/containers/registry/registry.access.redhat.com/repository/rhel9/squid
-    image: ${CORPORATE_PROXY_IMAGE:-registry.redhat.io/rhel9/squid:9.5}
+    image: "${CORPORATE_PROXY_IMAGE:-docker.io/ubuntu/squid:latest}"
     environment:
       - TS=UTC
-    entrypoint: [ '/usr/local/bin/start-squid.sh' ]
-    volumes:
-      - type: bind
-        source: "./start-squid.sh"
-        target: "/usr/local/bin/start-squid.sh"
-        bind:
-          selinux: "Z"
     networks:
       - internal_net
       - default
@@ -37,6 +30,12 @@ services:
       # NO_PROXY configured in the .env file, but can be overridden here
     networks:
       - internal_net
+      # TODO(rm3l): There is a limitation with networks that have "internal: true": ports are not published with Docker, but are with Podman.
+      # So with Docker, port forwarding does not work at all from the host, because the host port is not exposed.
+      # See https://github.com/moby/moby/issues/36174
+      # As a workaround, we are adding it to the default network,
+      # but note that there is nothing preventing requests from bypassing the proxy to reach the outside.
+      - default
 
   install-dynamic-plugins:
     environment:

--- a/compose.yaml
+++ b/compose.yaml
@@ -21,14 +21,14 @@ services:
 
   rhdh:
     container_name: rhdh
-    image: ${RHDH_IMAGE}
+    image: ${RHDH_IMAGE} # dclint disable-line service-image-require-explicit-tag
     env_file:
       - path: "./.env"
         required: true
     user: "1001"
     entrypoint:
       - "/opt/app-root/src/wait-for-plugins.sh"
-    ports:
+    ports: # dclint disable-line no-unbound-port-interfaces
       - "7007:7007"
     volumes:
       - type: bind
@@ -54,7 +54,7 @@ services:
 
   install-dynamic-plugins:
     container_name: rhdh-plugins-installer
-    image: ${RHDH_IMAGE}
+    image: ${RHDH_IMAGE} # dclint disable-line service-image-require-explicit-tag
     # docker compose volumes are owned by root, so we need to run as root to write to them
     # the main rhdh container will be able to read from this as files are world readable
     user: "root"

--- a/start-squid.sh
+++ b/start-squid.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+tail -vn 0 -F /var/log/squid/{access,cache,error,store}.log &
+
+# in case of using cache dir, we need to initialize it
+squid -d 1 --foreground -f /etc/squid/squid.conf -z
+
+# now start the squid primary process with supplied options
+squid -d 1 --foreground -f /etc/squid/squid.conf $@

--- a/start-squid.sh
+++ b/start-squid.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-tail -vn 0 -F /var/log/squid/{access,cache,error,store}.log &
-
-# in case of using cache dir, we need to initialize it
-squid -d 1 --foreground -f /etc/squid/squid.conf -z
-
-# now start the squid primary process with supplied options
-squid -d 1 --foreground -f /etc/squid/squid.conf $@


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description

This PR improves the existing CI checks by:
- adding a linter against all the compose files. It also fixes the blocking errors that were reported by this linter.
- making sure to test the existing compose configurations using both docker-compose and podman-compose. Note that this allowed me to catch an issue with the `compose-with-corporate-proxy.yaml`, where the ports were being handled differently on Podman vs Docker.

## Which issue(s) does this PR fix or relate to

- Fixes https://issues.redhat.com/browse/RHIDP-6155

## PR acceptance criteria

- [x] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer

See the CI checks for this PR: https://github.com/redhat-developer/rhdh-local/actions/runs/13943538651?pr=32

/cc @kadel 