### PR TITLE
chore: Better handle the user-provided `.env` file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,9 +48,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: prepare .env
-      run: cp env.sample .env
-
     - name: Install tool
       if: ${{ matrix.tool == 'podman' }}
       env:

--- a/README.md
+++ b/README.md
@@ -32,13 +32,8 @@ To use RHDH Local you'll need a few things:
    cd rhdh-local
    ```
 
-1. Create your own local `.env` file by using a copy of the `env.sample` provided.
-
-   ```sh
-   cp env.sample .env
-   ```
-
-   In most cases, when you don't need GitHub Auth or testing different releases you can leave it as it is, and it should work.
+1. (Optional) You can create a local `.env` file and override any of the default variables defined in the [`default.env`](./default.env) file provided. You can also add additional variables.
+   In most cases, when you don't need GitHub Auth or testing different releases, you can skip this step, and it should work.
 
 1. (Optional) Update `configs/app-config.local.yaml`.
    If you need features that fetch files from GitHub you should configure `integrations.github`.
@@ -189,8 +184,10 @@ If you want to use PostgreSQL with RHDH, here are the steps:
      volumes:
        - "/var/lib/pgsql/data"
      env_file:
-       - path: "./.env"
+       - path: "./default.env"
          required: true
+       - path: "./.env"
+         required: false
      environment:
        - POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD}
      healthcheck:

--- a/compose.yaml
+++ b/compose.yaml
@@ -23,7 +23,7 @@ services:
 
   rhdh:
     container_name: rhdh
-    image: ${RHDH_IMAGE} # dclint disable-line service-image-require-explicit-tag
+    image: ${RHDH_IMAGE:-quay.io/rhdh/rhdh-hub-rhel9:1.4} # dclint disable-line service-image-require-explicit-tag
     env_file:
       - path: "./default.env"
         required: true
@@ -58,7 +58,7 @@ services:
 
   install-dynamic-plugins:
     container_name: rhdh-plugins-installer
-    image: ${RHDH_IMAGE} # dclint disable-line service-image-require-explicit-tag
+    image: ${RHDH_IMAGE:-quay.io/rhdh/rhdh-hub-rhel9:1.4} # dclint disable-line service-image-require-explicit-tag
     # docker compose volumes are owned by root, so we need to run as root to write to them
     # the main rhdh container will be able to read from this as files are world readable
     user: "root"

--- a/compose.yaml
+++ b/compose.yaml
@@ -23,7 +23,7 @@ services:
 
   rhdh:
     container_name: rhdh
-    image: ${RHDH_IMAGE:-quay.io/rhdh/rhdh-hub-rhel9:1.4} # dclint disable-line service-image-require-explicit-tag
+    image: ${RHDH_IMAGE:-quay.io/rhdh/rhdh-hub-rhel9:1.4}
     env_file:
       - path: "./default.env"
         required: true
@@ -58,7 +58,7 @@ services:
 
   install-dynamic-plugins:
     container_name: rhdh-plugins-installer
-    image: ${RHDH_IMAGE:-quay.io/rhdh/rhdh-hub-rhel9:1.4} # dclint disable-line service-image-require-explicit-tag
+    image: ${RHDH_IMAGE:-quay.io/rhdh/rhdh-hub-rhel9:1.4}
     # docker compose volumes are owned by root, so we need to run as root to write to them
     # the main rhdh container will be able to read from this as files are world readable
     user: "root"

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,8 +9,10 @@ services:
   #   volumes:
   #     - "/var/lib/pgsql/data"
   #   env_file:
-  #     - path: "./.env"
+  #     - path: "./default.env"
   #       required: true
+  #     - path: "./.env"
+  #       required: false
   #   environment:
   #     - POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD}
   #   healthcheck:
@@ -23,8 +25,10 @@ services:
     container_name: rhdh
     image: ${RHDH_IMAGE} # dclint disable-line service-image-require-explicit-tag
     env_file:
-      - path: "./.env"
+      - path: "./default.env"
         required: true
+      - path: "./.env"
+        required: false
     user: "1001"
     entrypoint:
       - "/opt/app-root/src/wait-for-plugins.sh"
@@ -61,8 +65,10 @@ services:
     entrypoint:
       - ./fixes.sh
     env_file:
-      - path: "./.env"
+      - path: "./default.env"
         required: true
+      - path: "./.env"
+        required: false
     volumes:
       - type: bind
         source: "./fixes.sh"

--- a/default.env
+++ b/default.env
@@ -25,15 +25,15 @@ SEGMENT_WRITE_KEY=gGVM6sYRK0D0ndVX22BOtS7NRcxPej8t
 #SEGMENT_TEST_MODE=true
 
 # Backstage log level
-LOG_LEVEL=debug
+#LOG_LEVEL=debug
 
 # Logs from global-agent to inspect the 'node-fetch' behavior with proxy settings
-ROARR_LOG=true
+#ROARR_LOG=true
 
 # Logs from fetch.
 # Might be useful to inspect the 'fetch' behavior with proxy settings (handled by 'undici', not 'global-agent')
-NODE_DEBUG=fetch
+#NODE_DEBUG=fetch
 
 # NO_PROXY will take effect only if HTTP(S)_PROXY env vars are set.
 # See the compose-with-corporate-proxy.yaml file.
-NO_PROXY=localhost,127.0.0.1
+#NO_PROXY=localhost,127.0.0.1

--- a/default.env
+++ b/default.env
@@ -8,8 +8,7 @@ POSTGRES_PASSWORD=postgres
 BASE_URL=http://localhost:7007
 
 # configure images to use
-RHDH_IMAGE=quay.io/rhdh/rhdh-hub-rhel9:1.4
-
+# RHDH_IMAGE=quay.io/rhdh/rhdh-hub-rhel9:1.4
 # This is an nightly build. This image is available for both amd64 and arm64
 #RHDH_IMAGE=quay.io/rhdh-community/rhdh:next
 


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
<!--
Please explain the changes you made here.
-->

This PR updates the Compose manifest by declaring two `env_files`:
- one is the default and is mandatory
- the second one is optional and can be provided by the user

What's interesting here is that, per the Compose spec [1], the files would be evaluated in order and can override values set in previous files.
This means that the user-provided `.env` file does not need to be an exact copy of the default (previously `env.sample`), but can just contain overrides for the variables needed (or define new ones).

I confirmed this behavior locally with both Podman Compose and Docker Compose.

[1] https://github.com/compose-spec/compose-spec/blob/main/spec.md#env_file

## Which issue(s) does this PR fix or relate to

- Relates to https://issues.redhat.com/browse/RHIDP-4263

## PR acceptance criteria

- [x] Tests
- [x] Documentation

## How to test changes / Special notes to the reviewer

Running `podman compose up -d` or `docker compose up -d` should work even if there is no local `.env` file. The `.env` file also does not need to be a copy of `default.env` - it can just contain the necessary overrides or define extra env vars.

/cc @kadel @benwilcock 
