### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To use RHDH Local you'll need a few things:
 
 ### Note
    For Mac M1 users, If you're using an Apple Silicon (M1/M2) Mac,
-   the default RHDH image (quay.io/rhdh/rhdh-hub-rhel9:1.4) is not compatible with the ARM64 architecture.To fix this, open your .env file and uncomment
+   the default RHDH image (quay.io/rhdh/rhdh-hub-rhel9:1.4) is not compatible with the ARM64 architecture. To fix this, open your `.env` file and uncomment
    or replace the RHDH_IMAGE line with the following image that supports both amd64 and arm64: `RHDH_IMAGE=quay.io/rhdh-community/rhdh:next`
 
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ To use RHDH Local you'll need a few things:
 
 If you're using an Apple Silicon (M1/M2) Mac, the default RHDH image (`quay.io/rhdh/rhdh-hub-rhel9:1.4`) is not compatible with the ARM64 architecture.
 To fix this, you can add this line to your `.env` file (create the file if it doesn't exist):
+
 `RHDH_IMAGE=quay.io/rhdh-community/rhdh:next`
 
 This image supports both `amd64` and `arm64`.

--- a/README.md
+++ b/README.md
@@ -18,11 +18,13 @@ To use RHDH Local you'll need a few things:
 1. (Optional) The node `npx` tool (if you intend to use GitHub authentication in RHDH)
 1. (Optional) A [Red Hat account](https://access.redhat.com/RegistryAuthentication#getting-a-red-hat-login-2) (if you want to use a PostgreSQL database)
 
-### Note
-   For Mac M1 users, if you're using an Apple Silicon (M1/M2) Mac, the default RHDH image (`quay.io/rhdh/rhdh-hub-rhel9:1.4`) is not compatible with the ARM64 architecture. To fix this, add this line to your `.env` file (create the file if it doesn't exist): `RHDH_IMAGE=quay.io/rhdh-community/rhdh:next`
-   This image supports both `amd64` and `arm64`.
+### Note for Mac M1 users
 
+If you're using an Apple Silicon (M1/M2) Mac, the default RHDH image (`quay.io/rhdh/rhdh-hub-rhel9:1.4`) is not compatible with the ARM64 architecture.
+To fix this, you can add this line to your `.env` file (create the file if it doesn't exist):
+`RHDH_IMAGE=quay.io/rhdh-community/rhdh:next`
 
+This image supports both `amd64` and `arm64`.
 ## Getting Started With RHDH Local
 
 1. Clone this repository to a location on your PC

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ To use RHDH Local you'll need a few things:
 1. (Optional) The node `npx` tool (if you intend to use GitHub authentication in RHDH)
 1. (Optional) A [Red Hat account](https://access.redhat.com/RegistryAuthentication#getting-a-red-hat-login-2) (if you want to use a PostgreSQL database)
 
+### Note
+   For Mac M1 users, If you're using an Apple Silicon (M1/M2) Mac,
+   the default RHDH image (quay.io/rhdh/rhdh-hub-rhel9:1.4) is not compatible with the ARM64 architecture.To fix this, open your .env file and uncomment
+   or replace the RHDH_IMAGE line with the following image that supports both amd64 and arm64: `RHDH_IMAGE=quay.io/rhdh-community/rhdh:next`
+
+
 ## Getting Started With RHDH Local
 
 1. Clone this repository to a location on your PC

--- a/README.md
+++ b/README.md
@@ -19,9 +19,8 @@ To use RHDH Local you'll need a few things:
 1. (Optional) A [Red Hat account](https://access.redhat.com/RegistryAuthentication#getting-a-red-hat-login-2) (if you want to use a PostgreSQL database)
 
 ### Note
-   For Mac M1 users, If you're using an Apple Silicon (M1/M2) Mac,
-   the default RHDH image (quay.io/rhdh/rhdh-hub-rhel9:1.4) is not compatible with the ARM64 architecture. To fix this, open your `.env` file and uncomment
-   or replace the RHDH_IMAGE line with the following image that supports both amd64 and arm64: `RHDH_IMAGE=quay.io/rhdh-community/rhdh:next`
+   For Mac M1 users, if you're using an Apple Silicon (M1/M2) Mac, the default RHDH image (`quay.io/rhdh/rhdh-hub-rhel9:1.4`) is not compatible with the ARM64 architecture. To fix this, add this line to your `.env` file (create the file if it doesn't exist): `RHDH_IMAGE=quay.io/rhdh-community/rhdh:next`
+   This image supports both `amd64` and `arm64`.
 
 
 ## Getting Started With RHDH Local


### PR DESCRIPTION

### 🐳 Fix: Support RHDH Local on Apple Silicon (ARM64)

This PR updates readme.md instructions guiding users to use the default container image to `quay.io/rhdh-community/rhdh:next` for improved compatibility on Apple Silicon (M1/M2) Macs.


