### PR TITLE
Updates to RHDH Local TechDocs

### DIFF
--- a/configs/catalog-entities/components.yaml
+++ b/configs/catalog-entities/components.yaml
@@ -29,26 +29,51 @@
 apiVersion: backstage.io/v1alpha1
 kind: System
 metadata:
-  name: red-hat-developer-hub
-  description: "Red Hat Developer Hub is a place where developers can create, share, discover, and manage your organization's code. Based on Spotify Backstage."
+  name: rhdh-local
+  title: RHDH Local
+  description: |
+    RHDH Local is used by platform engineers to test and experiment with RHDH configuration with a faster inner loop cycle time. 
+    RHDH Local offers a faster cycle time because it uses Docker or PodMan to run the RHDH container. No Kubernetes is required.
+    When writing and testing TechDocs, Templates, or Catalog items, RHDH Local offers a fast and simple solution that lets you 
+    work quickly and retain full control over your setup and your database.
   tags:
-    - backstage
-    - developer
-    - hub
-    - redhat
+    - developer-hub
+    - rhdh-local
   links:
+    - url: https://red.ht/rhdh
+      title: Red Hat Developer Hub website
+      icon: star
+      type: website
+    - url: https://developers.redhat.com/blog
+      title: Red Hat Developer Blog
+      icon: catalog
+      type: blog
+    - url: https://docs.redhat.com/fr/documentation/red_hat_developer_hub/
+      title: Official RHDH Documentation
+      icon: docs
+      type: docs
+    - url: https://issues.redhat.com/browse/RHIDP
+      title: Red Hat Developer Hub Jira
+      icon: help
+      type: jira
+    - url: https://github.com/redhat-developer/rhdh-local
+      title: RHDH-Local source code on GitHub
+      icon: github
+      type: sourcecode
     - url: https://youtu.be/LB1w8hjBt5k?si=2LxmEtIxIyAKcHx6
       title: Red Hat Developer Hub Overview
       type: video
       icon: YouTube
-    - url: https://developers.redhat.com/rhdh/overview
-      title: Red Hat Developer Hub Homepage
-      type: website
-      icon: WebAsset
   annotations:
     backstage.io/techdocs-ref: dir:.
+    feedback/type: 'MAIL' # allows for feedback via EMAIL
+    feedback/email-to: ${EMAIL_SENDER} # Sets where the EMAIL feedback is to go
+    quay.io/repository-slug: rhdh-community/rhdh
+    github.com/project-slug: redhat-developer/rhdh-local
+    github.com/team-slug: redhat-developer/rhdh-team
 spec: 
-  owner: user:user
+  owner: user:default/user
+  type: product
   lifecycle: production
   profile:
-    displayName: Red Hat Developer Hub
+    displayName: RHDH Local

--- a/configs/catalog-entities/components.yaml
+++ b/configs/catalog-entities/components.yaml
@@ -33,15 +33,15 @@ metadata:
   title: RHDH Local
   description: |
     RHDH Local is used by platform engineers to test and experiment with RHDH configuration with a faster inner loop cycle time. 
-    RHDH Local offers a faster cycle time because it uses Docker or PodMan to run the RHDH container. No Kubernetes is required.
+    RHDH Local uses Docker or PodMan to run the RHDH container. No Kubernetes is required.
     When writing and testing TechDocs, Templates, or Catalog items, RHDH Local offers a fast and simple solution that lets you 
-    work quickly and retain full control over your setup and your database.
+    work quickly and retain full control over your setup and your database. See the TechDocs for more details.
   tags:
     - developer-hub
     - rhdh-local
   links:
     - url: https://red.ht/rhdh
-      title: Red Hat Developer Hub website
+      title: RHDH Homepage
       icon: star
       type: website
     - url: https://developers.redhat.com/blog
@@ -49,19 +49,19 @@ metadata:
       icon: catalog
       type: blog
     - url: https://docs.redhat.com/fr/documentation/red_hat_developer_hub/
-      title: Official RHDH Documentation
+      title: RHDH Documentation
       icon: docs
       type: docs
     - url: https://issues.redhat.com/browse/RHIDP
-      title: Red Hat Developer Hub Jira
+      title: RHDH Jira
       icon: help
       type: jira
     - url: https://github.com/redhat-developer/rhdh-local
-      title: RHDH-Local source code on GitHub
+      title: RHDH Local Source Code
       icon: github
       type: sourcecode
     - url: https://youtu.be/LB1w8hjBt5k?si=2LxmEtIxIyAKcHx6
-      title: Red Hat Developer Hub Overview
+      title: RHDH Video Overview (YouTube)
       type: video
       icon: YouTube
   annotations:

--- a/configs/catalog-entities/docs/comparison.md
+++ b/configs/catalog-entities/docs/comparison.md
@@ -6,26 +6,26 @@ Red Hat Developer Hub, built on top of Backstage, offers an enterprise-ready alt
 
 | Feature | CNCF Backstage | Red Hat Developer Hub |
 |--------|----------------|------------------------|
-| Software Catalog | ✔ | ✔ |
-| Software Templates (Scaffolder) | ✔ | ✔ |
-| TechDocs | ✔ | ✔ |
-| Global Search and Query | ✔ | ✔ |
-| Kubernetes Helm-based Installer | ✔ | ✔ |
-| Kubernetes Operator-based Installer | ✘ | ✔ |
-| Zero-Code solution (no need to maintain Backstage code) | ✘ | ✔ |
-| 24x7 Enterprise Support | ✘ | ✔ |
-| Supported on all major K8s platforms (GKE, AKS, EKS, OpenShift) | ✘ | ✔ |
-| Enterprise Grade Security | ✘ | ✔ |
-| Secure RHEL-based UBI Container | ✘ | ✔ |
-| Fast-track Security Fixes (Rapid CVE resolution) | ✘ | ✔ |
-| Authentication (e.g., Keycloak federated, Ping Federate) | ✘ | ✔ |
-| Audit Logging (template/catalog actions) | ✘ | ✔ |
-| Role-Based Access Control (RBAC) with GUI | ✘ | ✔ |
-| Workflow Automation Engine (Orchestrator) | ✘ | ✔ |
-| Docker/Podman Local Installation (faster inner-loop development) | ✘ | ✔ |
-| Dynamic Plug-Ins (no need to recompile) | ✘ | ✔ |
-| Verified Plugin Compatibility | ✘ (self-verify) | ✔ |
-| Extensions Catalog Plugin (marketplace) | ✘ | ✔ |
-| Adoption Insights Plugin (user metrics) | ✘ | ✔ |
-| 20+ Red Hat Plugins (e.g., Tekton, ArgoCD, Kiali, 3scale, ACS, Ansible) | ✘ | ✔ |
-| [Free Software Templates Library](https://github.com/redhat-developer/red-hat-developer-hub-software-templates) | ✘ | ✔ |
+| Software Catalog | <span style="color:green">✔</span> | <span style="color:green">✔</span> |
+| Software Templates (Scaffolder) | <span style="color:green">✔</span> | <span style="color:green">✔</span> |
+| TechDocs | <span style="color:green">✔</span> | <span style="color:green">✔</span> |
+| Global Search and Query | <span style="color:green">✔</span> | <span style="color:green">✔</span> |
+| Kubernetes Helm-based Installer | <span style="color:green">✔</span> | <span style="color:green">✔</span> |
+| Kubernetes Operator-based Installer | <span style="color:red">✘</span> | <span style="color:green">✔</span> |
+| Zero-Code solution (no need to maintain Backstage code) | <span style="color:red">✘</span> | <span style="color:green">✔</span> |
+| 24x7 Enterprise Support | <span style="color:red">✘</span> | <span style="color:green">✔</span> |
+| Supported on all major K8s platforms (GKE, AKS, EKS, OpenShift) | <span style="color:red">✘</span> | <span style="color:green">✔</span> |
+| Enterprise Grade Security | <span style="color:red">✘</span> | <span style="color:green">✔</span> |
+| Secure RHEL-based UBI Container | <span style="color:red">✘</span> | <span style="color:green">✔</span> |
+| Fast-track Security Fixes (Rapid CVE resolution) | <span style="color:red">✘</span> | <span style="color:green">✔</span> |
+| Authentication (e.g., Keycloak federated, Ping Federate) | <span style="color:red">✘</span> | <span style="color:green">✔</span> |
+| Audit Logging (template/catalog actions) | <span style="color:red">✘</span> | <span style="color:green">✔</span> |
+| Role-Based Access Control (RBAC) with GUI | <span style="color:red">✘</span> | <span style="color:green">✔</span> |
+| Workflow Automation Engine (Orchestrator) | <span style="color:red">✘</span> | <span style="color:green">✔</span> |
+| Docker/Podman Local Installation (faster inner-loop development) | <span style="color:red">✘</span> | <span style="color:green">✔</span> |
+| Dynamic Plug-Ins (no need to recompile) | <span style="color:red">✘</span> | <span style="color:green">✔</span> |
+| Verified Plugin Compatibility | <span style="color:#e6c200">✘</span> (self-verify) | <span style="color:green">✔</span> |
+| Extensions Catalog Plugin (marketplace) | <span style="color:red">✘</span> | <span style="color:green">✔</span> |
+| Adoption Insights Plugin (user metrics) | <span style="color:red">✘</span> | <span style="color:green">✔</span> |
+| 20+ Red Hat Plugins (e.g., Tekton, ArgoCD, Kiali, 3scale, ACS, Ansible) | <span style="color:red">✘</span> | <span style="color:green">✔</span> |
+| [Free Software Templates Library](https://github.com/redhat-developer/red-hat-developer-hub-software-templates) | <span style="color:red">✘</span> | <span style="color:green">✔</span> |

--- a/configs/catalog-entities/docs/comparison.md
+++ b/configs/catalog-entities/docs/comparison.md
@@ -1,0 +1,31 @@
+
+
+This document compares Red Hat Developer Hub and CNCF Backstage. 
+
+## Feature Comparison
+
+| Feature | CNCF Backstage | Red Hat Developer Hub |
+|--------|----------------|------------------------|
+| Software Catalog | ✔ | ✔ |
+| Software Templates (Scaffolder) | ✔ | ✔ |
+| TechDocs | ✔ | ✔ |
+| Global Search and Query | ✔ | ✔ |
+| Kubernetes Helm-based Installer | ✔ | ✔ |
+| Kubernetes Operator-based Installer | ✘ | ✔ |
+| Zero-Code solution (no need to maintain Backstage code) | ✘ | ✔ |
+| 24x7 Enterprise Support | ✘ | ✔ |
+| Supported on all major K8s platforms (GKE, AKS, EKS, OpenShift) | ✘ | ✔ |
+| Enterprise Grade Security | Community Support Only | World-Class 24x7 |
+| Secure RHEL-based UBI Container | ✘ | ✔ |
+| Fast-track Security Fixes (Rapid CVE resolution) | ✘ | ✔ |
+| Authentication (e.g., Keycloak federated, Ping Federate) | ✘ | ✔ |
+| Audit Logging (template/catalog actions) | ✘ | ✔ |
+| Role-Based Access Control (RBAC) with GUI | ✘ | ✔ |
+| Workflow Automation Engine (Orchestrator) | ✘ | ✔ |
+| Docker/Podman Local Installation (faster inner-loop development) | ✘ | ✔ |
+| Dynamic Plug-Ins (no need to recompile) | ✘ | ✔ |
+| Verified Plugin Compatibility | ✘ (self-verify) | ✔ |
+| Extensions Catalog Plugin (marketplace) | ✘ | ✔ |
+| Adoption Insights Plugin (user metrics) | ✘ | ✔ |
+| 20+ Red Hat Plugins (e.g., Tekton, ArgoCD, Kiali, 3scale, ACS, Ansible) | ✘ | ✔ |
+| [Free Software Templates Library](https://github.com/redhat-developer/red-hat-developer-hub-software-templates) | ✘ | ✔ |

--- a/configs/catalog-entities/docs/comparison.md
+++ b/configs/catalog-entities/docs/comparison.md
@@ -1,6 +1,6 @@
+Choosing the right internal developer portal (IDP) is a critical decision for engineering teams aiming to improve their developer experience, streamline software delivery, and adopt DevOps best practices. CNCF Backstage has become a popular open-source framework for building IDPs, but it often requires significant customization, manual plugin integration, and ongoing maintenance effort.
 
-
-This document compares Red Hat Developer Hub and CNCF Backstage. 
+Red Hat Developer Hub, built on top of Backstage, offers an enterprise-ready alternative. It provides a curated, fully supported, and production-hardened solution out of the box — eliminating many of the complexities associated with a DIY Backstage setup. The matrix below highlights key differences to help enterrpise platform engineering teams to figure out which solution best aligns best with their specific needs.
 
 ## Feature Comparison
 
@@ -15,7 +15,7 @@ This document compares Red Hat Developer Hub and CNCF Backstage.
 | Zero-Code solution (no need to maintain Backstage code) | ✘ | ✔ |
 | 24x7 Enterprise Support | ✘ | ✔ |
 | Supported on all major K8s platforms (GKE, AKS, EKS, OpenShift) | ✘ | ✔ |
-| Enterprise Grade Security | Community Support Only | World-Class 24x7 |
+| Enterprise Grade Security | ✘ | ✔ |
 | Secure RHEL-based UBI Container | ✘ | ✔ |
 | Fast-track Security Fixes (Rapid CVE resolution) | ✘ | ✔ |
 | Authentication (e.g., Keycloak federated, Ping Federate) | ✘ | ✔ |

--- a/configs/catalog-entities/docs/extensions.md
+++ b/configs/catalog-entities/docs/extensions.md
@@ -1,0 +1,183 @@
+# Making Your TechDocs More Appealing
+
+Other MKdocs extensions that work in TAP and TDP. Taken and tested from the reference documentation [here](https://squidfunk.github.io/mkdocs-material/reference/).
+
+## Quotes
+
+!!! quote "This is a quote"
+    You don't have to add a title to an admonition, they're optional.
+
+## Callouts (Admonitions)
+
+There are lots of types to choose from. See [here](https://squidfunk.github.io/mkdocs-material/reference/admonitions/).
+
+!!! info "This is a regular callout"
+    There are lots of types to choose from. See [here](https://squidfunk.github.io/mkdocs-material/reference/admonitions/).
+
+!!! warn "This is a warning"
+    This callout contains a warning.
+
+???+ info "Expanded"
+    This is expanded by default.
+
+??? tip "Contracted"
+    This is contracted by default
+
+## Content Tabs
+
+Particularly useful for code blocks for different programming languages or platforms, but could have many other users.
+
+=== "Mac OS & Linux"
+
+    ```bash
+    # Extract the tar archive into your ~/tanzu directory
+    tar -xvf tanzu-framework-linux-amd64.tar -C ./tanzu
+    ```
+
+=== "Windows"
+
+    ```powershell
+    # Extract the zip
+    Expand-Archive .\tanzu-framework-windows-amd64.zip
+    ```
+
+=== "Text"
+
+    You can have what you like in here, just like an admonition. It doesn't *have* to be code blocks :smile:.
+
+## Buttons
+
+[Subscribe to our newsletter](#){ .md-button }
+
+!!! note "More diagrams and examples"
+    You can find much more information about PlantUML and samples to try on their [website](https://plantuml.com/). Use the links at th top of the page for samples.
+
+## Footnotes
+
+Lorem ipsum[^1] dolor sit amet, consectetur adipiscing elit.[^2]
+
+[^1]: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+[^2]:
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla et euismod nulla. Curabitur feugiat, tortor non consequat finibus, justo purus auctor massa, nec semper lorem quam in massa.
+
+## Text Formatting
+
+Text can be {--deleted--} and replacement text {++added++}. This can also be combined into {~~one~>a single~~} operation. {==Highlighting==} is also
+possible {>>and comments can be added inline<<}.
+
+{==
+
+Formatting can also be applied to blocks by putting the opening and closing
+tags on separate lines and adding new lines between the tags and the content.
+
+==}
+
+- ==This was marked==
+- ^^This was inserted^^
+- ~~This was deleted~~
+
+- Subtext H~2~O
+- Supertext A^T^A
+
+## Task Lists
+
+Automatic rendering of Markdown task lists.
+
+- [x] Phase 1
+- [x] Phase 2
+- [ ] Phase 3
+
+## Emoji
+
+:smile: You can use Emoji's. Find the shortcodes [here](https://emojipedia.org/) :heart:.
+
+## Images
+
+=== "Image LEFT"
+
+    ![Image title](https://dummyimage.com/600x400/eee/aaa){ align=left }
+
+=== "Image RIGHT"
+
+    ![Image title](https://dummyimage.com/600x400/eee/aaa){ align=right }
+
+=== "Image RESIZE"
+
+    ![Image title](https://dummyimage.com/600x400/eee/aaa){ align=right width="200" }
+
+You can add captions.
+
+<figure markdown>
+  ![Image title](https://dummyimage.com/600x400/){ width="300" }
+  <figcaption>Image caption</figcaption>
+</figure>
+
+## Special Lists
+
+**This is a definition list. Notice the indentation.**
+
+`Lorem ipsum dolor sit amet`
+
+:   Sed sagittis eleifend rutrum. Donec vitae suscipit est. Nullam tempus
+    tellus non sem sollicitudin, quis rutrum leo facilisis.
+
+`Cras arcu libero`
+
+:   Aliquam metus eros, pretium sed nulla venenatis, faucibus auctor ex. Proin
+    ut eros sed sapien ullamcorper consequat. Nunc ligula ante.
+
+    Duis mollis est eget nibh volutpat, fermentum aliquet dui mollis.
+    Nam vulputate tincidunt fringilla.
+    Nullam dignissim ultrices urna non auctor.
+
+**This is a task list, with done and not done items.**
+
+- [x] Lorem ipsum dolor sit amet, consectetur adipiscing elit
+- [ ] Vestibulum convallis sit amet nisi a tincidunt
+- [ ] Aenean pretium efficitur erat, donec pharetra, ligula non scelerisque
+
+
+## MDX truly sane lists
+
+- `attributes`
+
+- `customer`
+  - `first_name`
+    - `test`
+  - `family_name`
+  - `email`
+- `person`
+  - `first_name`
+  - `family_name`
+  - `birth_date`
+- `subscription_id`
+
+- `request`
+
+## Tool tips
+
+Links can have tool tips.
+
+[Link with tool tip](https://example.com "I'm a tooltip!")
+
+Link with tooltip (reference syntax)
+
+[Hover me][example]
+
+[example]: https://example.com "I'm a tooltip!"
+
+
+## Download Links
+
+[A Download Link](./images/backstage-logo-cncf.svg){: download }
+
+
+## Abbreviations
+
+The HTML specification is maintained by the W3C.
+
+*[HTML]: Hyper Text Markup Language
+*[W3C]: World Wide Web Consortium
+*[TAP]: VMware Tanzu Application Platform
+*[TDP]: WMware Tanzu Developer Portal

--- a/configs/catalog-entities/docs/extensions.md
+++ b/configs/catalog-entities/docs/extensions.md
@@ -5,11 +5,11 @@ Using the following MKdocs extensions can make your TechDocs can make the user e
 ## Quotes
 
 !!! quote "This is a quote"
-    You don't have to add a title to an admonition, they're optional.
+    You don't have to add a title to a quote, they're optional.
 
 ## Callouts (Admonitions)
 
-There are lots of types to choose from. See [here](https://squidfunk.github.io/mkdocs-material/reference/admonitions/).
+There are lots of types to choose from. You don't have to add a title to an admonition, they're optional. See [here](https://squidfunk.github.io/mkdocs-material/reference/admonitions/).
 
 !!! info "This is a regular callout"
     There are lots of types to choose from. See [here](https://squidfunk.github.io/mkdocs-material/reference/admonitions/).
@@ -31,14 +31,14 @@ Particularly useful for code blocks for different programming languages or platf
 
     ```bash
     # Extract the tar archive into your ~/tanzu directory
-    tar -xvf tanzu-framework-linux-amd64.tar -C ./tanzu
+    tar -xvf my-bundle.tar -C ./tanzu
     ```
 
 === "Windows"
 
     ```powershell
     # Extract the zip
-    Expand-Archive .\tanzu-framework-windows-amd64.zip
+    Expand-Archive .\my-bundle.zip
     ```
 
 === "Text"
@@ -173,11 +173,8 @@ Link with tooltip (reference syntax)
 [A Download Link](./images/backstage-logo-cncf.svg){: download }
 
 
-## Abbreviations
+## Abbreviations & Acronyms
 
-The HTML specification is maintained by the W3C.
+Define an abbreviation once and wherever it appears on the page it will be underlined. Hover over the underlined abbreviation and the expanded abbreviation is shown as a tool tip. No more wondering what "CNCF" stands for!
 
-*[HTML]: Hyper Text Markup Language
-*[W3C]: World Wide Web Consortium
-*[TAP]: VMware Tanzu Application Platform
-*[TDP]: WMware Tanzu Developer Portal
+*[CNCF]: Cloud Native Compting Foundation

--- a/configs/catalog-entities/docs/extensions.md
+++ b/configs/catalog-entities/docs/extensions.md
@@ -1,5 +1,3 @@
-# Making Your TechDocs More Appealing
-
 Using the following MKdocs extensions can enhance your TechDocs, making the user experience richer and more appealing for the reader. These samples were developed based on the reference documentation [here](https://squidfunk.github.io/mkdocs-material/reference/). View the source code of this page to discover the correct markup to use for each item displayed below.
 
 ## Quotes

--- a/configs/catalog-entities/docs/extensions.md
+++ b/configs/catalog-entities/docs/extensions.md
@@ -12,13 +12,16 @@ There are lots of types to choose from. You don't have to add a title to an admo
 !!! info "This is an Info Card"
     There are lots of types to choose from. See [here](https://squidfunk.github.io/mkdocs-material/reference/admonitions/).
 
-!!! warn "This is a Warning Card"
+!!! warning "This is a Warning Card"
     This callout contains a warning.
 
-???+ info "This is an Expanded Info Card"
+!!! note "This is a Note Card"
+    This callout contains a note.
+
+???+ question "This Question Can Be Contracted"
     This is expanded by default (but can be contracted).
 
-??? tip "This is a Contracted Tip Card"
+??? tip "This Tip is Contracted (By Default)"
     This is contracted by default (but can be expanded).
 
 ## Content Tabs

--- a/configs/catalog-entities/docs/extensions.md
+++ b/configs/catalog-entities/docs/extensions.md
@@ -1,6 +1,6 @@
 # Making Your TechDocs More Appealing
 
-Using the following MKdocs extensions can make your TechDocs can make the user experience richer and more appealing for the reader. These samples were developed based on the the reference documentation [here](https://squidfunk.github.io/mkdocs-material/reference/). View the source code of this page to discover the correct markup to use for each item displayed below.
+Using the following MKdocs extensions can enhance your TechDocs, making the user experience richer and more appealing for the reader. These samples were developed based on the reference documentation [here](https://squidfunk.github.io/mkdocs-material/reference/). View the source code of this page to discover the correct markup to use for each item displayed below.
 
 ## Quotes
 

--- a/configs/catalog-entities/docs/extensions.md
+++ b/configs/catalog-entities/docs/extensions.md
@@ -1,6 +1,6 @@
 # Making Your TechDocs More Appealing
 
-Other MKdocs extensions that work in TAP and TDP. Taken and tested from the reference documentation [here](https://squidfunk.github.io/mkdocs-material/reference/).
+Using the following MKdocs extensions can make your TechDocs can make the user experience richer and more appealing for the reader. These samples were developed based on the the reference documentation [here](https://squidfunk.github.io/mkdocs-material/reference/). View the source code of this page to discover the correct markup to use for each item displayed below.
 
 ## Quotes
 

--- a/configs/catalog-entities/docs/extensions.md
+++ b/configs/catalog-entities/docs/extensions.md
@@ -11,17 +11,17 @@ Using the following MKdocs extensions can make your TechDocs can make the user e
 
 There are lots of types to choose from. You don't have to add a title to an admonition, they're optional. See [here](https://squidfunk.github.io/mkdocs-material/reference/admonitions/).
 
-!!! info "This is a regular callout"
+!!! info "This is an Info Card"
     There are lots of types to choose from. See [here](https://squidfunk.github.io/mkdocs-material/reference/admonitions/).
 
-!!! warn "This is a warning"
+!!! warn "This is a Warning Card"
     This callout contains a warning.
 
-???+ info "Expanded"
-    This is expanded by default.
+???+ info "This is an Expanded Info Card"
+    This is expanded by default (but can be contracted).
 
-??? tip "Contracted"
-    This is contracted by default
+??? tip "This is a Contracted Tip Card"
+    This is contracted by default (but can be expanded).
 
 ## Content Tabs
 
@@ -30,8 +30,8 @@ Particularly useful for code blocks for different programming languages or platf
 === "Mac OS & Linux"
 
     ```bash
-    # Extract the tar archive into your ~/tanzu directory
-    tar -xvf my-bundle.tar -C ./tanzu
+    # Extract the tar archive into your ~/downloads directory
+    tar -xvf my-bundle.tar -C ./downloads
     ```
 
 === "Windows"
@@ -90,9 +90,11 @@ Automatic rendering of Markdown task lists.
 
 ## Emoji
 
-:smile: You can use Emoji's. Find the shortcodes [here](https://emojipedia.org/) :heart:.
+:smile: You can use Emoji's in your writing! Find the shortcodes [here](https://emojipedia.org/) :heart:.
 
 ## Images
+
+You can align and resize images.
 
 === "Image LEFT"
 
@@ -106,16 +108,16 @@ Automatic rendering of Markdown task lists.
 
     ![Image title](https://dummyimage.com/600x400/eee/aaa){ align=right width="200" }
 
-You can add captions.
+You can add captions to your images.
 
 <figure markdown>
   ![Image title](https://dummyimage.com/600x400/){ width="300" }
-  <figcaption>Image caption</figcaption>
+  <figcaption>This image now has a caption.</figcaption>
 </figure>
 
 ## Special Lists
 
-**This is a definition list. Notice the indentation.**
+Below is a "definition list." Notice the indentation...
 
 `Lorem ipsum dolor sit amet`
 
@@ -131,7 +133,7 @@ You can add captions.
     Nam vulputate tincidunt fringilla.
     Nullam dignissim ultrices urna non auctor.
 
-**This is a task list, with done and not done items.**
+Below is a task list, with done and not done items...
 
 - [x] Lorem ipsum dolor sit amet, consectetur adipiscing elit
 - [ ] Vestibulum convallis sit amet nisi a tincidunt
@@ -161,7 +163,7 @@ Links can have tool tips.
 
 [Link with tool tip](https://example.com "I'm a tooltip!")
 
-Link with tooltip (reference syntax)
+Link with tooltip (using the separate 'reference' syntax).
 
 [Hover me][example]
 

--- a/configs/catalog-entities/docs/features.md
+++ b/configs/catalog-entities/docs/features.md
@@ -2,21 +2,21 @@
 
 Red Hat Developer Hub helps you and your team deliver better code with greater speed, confidence, and clarity. Here are some highlights of what you can expect when using the Red Hat Developer Hub...
 
-!!! success "**Higher Productivity**"
+!!! success "**Single Pane Of Glass**"
     Red Hat Developer Hub uses one consistent user interface to bring together. All your applications, services, teams, documentation, and APIs in one place. And, with Backstage compatible dynamic plugins, you can customize your experience faster by adding your favorite tools with less downtime.
 
-!!! success "**Templated 'Golden Paths'**"
+!!! success "**Golden Path Templates**"
     Capture your best practices as templates to help developers bootstrap new applications more quickly, follow your standard approaches, and stick to the golden path.
 
-!!! success "**Developer Self Service**"
+!!! success "**Self Service**"
     No more waiting around for IT tickets to complete or repetitive meetings. Automate your common tasks and empower your developers. Provide access to your most important things through Developer Hub and watch everyone go faster!
 
-!!! success "**Easy Extensibility**"
+!!! success "**Plugins, Plugins, Plugins!**"
     Red Hat Developer Hub is compatible with Backstage "dynamic plugins" giving you access to hundreds of additional integrations and features designed with developers in mind. Integrate your project management, software supply chain, CI/CD, observability, monitoring, metrics, reporting, infrastructure, security, testing, QA, and even state of the art AI chatbots!
 
-!!! success "**24/7 Enterprise Support**"
+!!! success "**Enterprise Grade Support**"
     In addition to the multitude of helpful resources maintained by the growing Backstage open-source community, Red Hat Developer Hub is also fully [supported by Red Hat](https://.red hat.com/support).
 
 !!! success "**Total Deployment Flexibility**"
-    Red Hat Developer Hub runs on any API-conformant Kubernetes distribution including Red Hat OpenShift, AWS, Azure, Google, and more. You can even run air-gapped for additional privacy and extra security.
+    Red Hat Developer Hub runs on any API-conformant Kubernetes distribution including Red Hat OpenShift, AWS, Azure, Google GKE, and more. You can even run air-gapped for additional privacy and extra security.
 

--- a/configs/catalog-entities/docs/features.md
+++ b/configs/catalog-entities/docs/features.md
@@ -1,5 +1,3 @@
-# Red Hat Developer Hub Highlights
-
 Red Hat Developer Hub helps you and your team deliver better code with greater speed, confidence, and clarity. Here are some highlights of what you can expect when using the Red Hat Developer Hub...
 
 !!! success "**Single Pane Of Glass**"
@@ -12,7 +10,7 @@ Red Hat Developer Hub helps you and your team deliver better code with greater s
     No more waiting around for IT tickets to complete or repetitive meetings. Automate your common tasks and empower your developers. Provide access to your most important things through Developer Hub and watch everyone go faster!
 
 !!! success "**Plugins, Plugins, Plugins!**"
-    Red Hat Developer Hub is compatible with Backstage "dynamic plugins" giving you access to hundreds of additional integrations and features designed with developers in mind. Integrate your project management, software supply chain, CI/CD, observability, monitoring, metrics, reporting, infrastructure, security, testing, QA, and even state of the art AI chatbots!
+    Red Hat Developer Hub is compatible with Backstage "dynamic plugins" giving you access to hundreds of additional integrations and features designed with developers in mind. Integrate your project management, software supply chain, CI/CD, observability, monitoring, metrics, reporting, infrastructure, security, testing, QA, and more!
 
 !!! success "**Enterprise Grade Support**"
     In addition to the multitude of helpful resources maintained by the growing Backstage open-source community, Red Hat Developer Hub is also fully [supported by Red Hat](https://.red hat.com/support).

--- a/configs/catalog-entities/docs/features.md
+++ b/configs/catalog-entities/docs/features.md
@@ -1,7 +1,7 @@
 Red Hat Developer Hub helps you and your team deliver better code with greater speed, confidence, and clarity. Here are some highlights of what you can expect when using the Red Hat Developer Hub...
 
 !!! success "**Turn-key Portal**"
-    One of the key differentiators of Red Hat Developer Hub is that its a true 'turn-key' solution. Unlike CNCF Backstage, which often requires additional coding effort and manual plugin integration to become fully functional, Red Hat Developer Hub comes ready to run out of the box. It provides a pre-configured, production-ready environment that eliminates the need for extensive setup or deep customization. This streamlined experience allows platform engineering teams to focus on delivering value rather than building and maintaining the developer portal infrastructure.
+    One of the key differentiators of Red Hat Developer Hub is that it is a true 'turn-key' solution. Unlike CNCF Backstage, which often requires additional coding effort and manual plugin integration to become fully functional, Red Hat Developer Hub comes ready to run out of the box. It provides a pre-configured, production-ready environment that eliminates the need for extensive setup or deep customization. This streamlined experience allows platform engineering teams to focus on delivering value rather than building and maintaining the developer portal infrastructure.
 
 !!! success "**Single Pane Of Glass For All Your Developers**"
     Red Hat Developer Hub uses one consistent user interface to bring together. All your applications, services, teams, documentation, and APIs in one place. And, with Backstage compatible dynamic plugins, you can customize your experience faster by adding your favorite tools with less downtime.

--- a/configs/catalog-entities/docs/features.md
+++ b/configs/catalog-entities/docs/features.md
@@ -1,20 +1,23 @@
 Red Hat Developer Hub helps you and your team deliver better code with greater speed, confidence, and clarity. Here are some highlights of what you can expect when using the Red Hat Developer Hub...
 
-!!! success "**Single Pane Of Glass**"
+!!! success "**Turn-key Portal**"
+    One of the key differentiators of Red Hat Developer Hub is that its a true 'turn-key' solution. Unlike CNCF Backstage, which often requires additional coding effort and manual plugin integration to become fully functional, Red Hat Developer Hub comes ready to run out of the box. It provides a pre-configured, production-ready environment that eliminates the need for extensive setup or deep customization. This streamlined experience allows platform engineering teams to focus on delivering value rather than building and maintaining the developer portal infrastructure.
+
+!!! success "**Single Pane Of Glass For All Your Developers**"
     Red Hat Developer Hub uses one consistent user interface to bring together. All your applications, services, teams, documentation, and APIs in one place. And, with Backstage compatible dynamic plugins, you can customize your experience faster by adding your favorite tools with less downtime.
 
-!!! success "**Golden Path Templates**"
+!!! success "**Golden Path Templates To Encourage Best Practices**"
     Capture your best practices as templates to help developers bootstrap new applications more quickly, follow your standard approaches, and stick to the golden path.
 
-!!! success "**Self Service**"
+!!! success "**Self Service For Greater Productivity**"
     No more waiting around for IT tickets to complete or repetitive meetings. Automate your common tasks and empower your developers. Provide access to your most important things through Developer Hub and watch everyone go faster!
 
-!!! success "**Plugins, Plugins, Plugins!**"
+!!! success "**Easy Extension With Plugins, Plugins, Plugins!**"
     Red Hat Developer Hub is compatible with Backstage "dynamic plugins" giving you access to hundreds of additional integrations and features designed with developers in mind. Integrate your project management, software supply chain, CI/CD, observability, monitoring, metrics, reporting, infrastructure, security, testing, QA, and more!
 
-!!! success "**Enterprise Grade Support**"
+!!! success "**Enterprise Grade Technical Support**"
     In addition to the multitude of helpful resources maintained by the growing Backstage open-source community, Red Hat Developer Hub is also fully [supported by Red Hat](https://.red hat.com/support).
 
-!!! success "**Total Deployment Flexibility**"
+!!! success "**Complete Deployment Flexibility**"
     Red Hat Developer Hub runs on any API-conformant Kubernetes distribution including Red Hat OpenShift, AWS, Azure, Google GKE, and more. You can even run air-gapped for additional privacy and extra security.
 

--- a/configs/catalog-entities/docs/index.md
+++ b/configs/catalog-entities/docs/index.md
@@ -1,6 +1,6 @@
 ![Red Hat Developer Hub](./images/hero-banner.jpg){ width="850" }
 
-Developers love :heart: Red Hat Developer Hub. Developer Hub makes creating, discovering, and managing enterprise software faster and more productive for everyone! With Developer Hub, applications and APIs deployed across your organisation become easier to find, easier to understand, and easier to control. Our enterprise grade support ensures you stay on target while our open source community brings you exciting new innovations on a regular basis. 
+Developers love :heart: Red Hat Developer Hub (RHDH). Developer Hub makes creating, discovering, and managing enterprise software faster and more productive for everyone! With Developer Hub, applications and APIs deployed across your organisation become easier to find, easier to understand, and easier to control. Our enterprise grade support ensures you stay on target while our open source community brings you exciting new innovations on a regular basis. 
 
 Some of the worlds largest companies use Red Hat Developer Hub to:
 
@@ -9,13 +9,10 @@ Some of the worlds largest companies use Red Hat Developer Hub to:
 * Improve access to critical documentation, APIs, and services
 * Integrate their favourite developer tools and dashboards in one handy portal 
 
-!!! tip "RHDH Proudly Based On [Backstage](https://backstage.io)"
+!!! tip "RHDH Proudly Based On CNCF Backstage"
 
-    Developer Hub is based on ~[![Backstage](images/Backstage-Full-BlackBG.png "Backstage"){ width="122" }](https://backstage.io)~ the open-source developer Hub from Spotify.  Backstage enjoys a vibrant user community and a fast growing ecosystem of useful extensions called "[plugins](https://developers.redhat.com/rhdh/plugins "plugins")". Many leading platform vendors (including  Red Hat) are contributing [code](https://github.com/janus-idp "source code") to the Backstage project to ensure the developer experience is as rich and rewarding as possible.
+    Developer Hub is based on [Backstage](https://backstage.io) the open-source Internal Developer Portal (IDP) created by Spotify and donated to the Cloud Native Computing Foundation (CNCF). CNCF Backstage enjoys a vibrant user community and a fast growing ecosystem of useful extensions called "[plugins](https://developers.redhat.com/rhdh/plugins "plugins")". Many leading platform vendors (including  Red Hat) are contributing [code](https://github.com/janus-idp "source code") to the Backstage project to ensure the developer experience is as rich and rewarding as possible.
 
-*[GUI]: Graphical User Interface (sometimes shortened to UI).
 *[IDP]: Internal Developer Platform - a system intended to make iy easier to develop, secure, operate, and manage applications running on your cloud infrastructure.
-
-<!-- !!! info "Feature Highlights & Getting Started"
-    
-    The [feature highlights](./features.md) of Developer Hub include an enhanced developer experience and greater developer productivity. Check out our [Getting Started Guide](./get-started.md) to quickly get up to speed with these features. -->
+*[CNCF]: Cloud Native Compting Foundation
+*[RHDH]: Red Hat Developer Hub

--- a/configs/catalog-entities/docs/index.md
+++ b/configs/catalog-entities/docs/index.md
@@ -14,5 +14,5 @@ Some of the worlds largest companies use Red Hat Developer Hub to:
     Developer Hub is based on [Backstage](https://backstage.io) the open-source Internal Developer Portal (IDP) created by Spotify and donated to the Cloud Native Computing Foundation (CNCF). CNCF Backstage enjoys a vibrant user community and a fast growing ecosystem of useful extensions called "[plugins](https://developers.redhat.com/rhdh/plugins "plugins")". Many leading platform vendors (including  Red Hat) are contributing [code](https://github.com/janus-idp "source code") to the Backstage project to ensure the developer experience is as rich and rewarding as possible.
 
 *[IDP]: Internal Developer Platform - a system intended to make iy easier to develop, secure, operate, and manage applications running on your cloud infrastructure.
-*[CNCF]: Cloud Native Compting Foundation
+*[CNCF]: Cloud Native Computing Foundation
 *[RHDH]: Red Hat Developer Hub

--- a/configs/catalog-entities/docs/ten_template_tips.md
+++ b/configs/catalog-entities/docs/ten_template_tips.md
@@ -62,7 +62,7 @@ spec:
 
 Software Templates can do much more than simply bootstrap Git repositories. Creative platform engineering teams can write templates that provision cloud resources using GitOps, trigger CI pipelines, open PRs to request approvals and much more. Take a look at the [RHDH Extensions Catalog](/extensions?filter=spec.categories%3DScaffolder) to find plugins that expose scaffolder actions you can utilize to create your own templates.
 
-!!! note "Free Software Template Samples"
+!!! abstract "Free Software Template Samples"
     Red Hat Developer Hub has a [free library of software templates](https://github.com/redhat-developer/red-hat-developer-hub-software-templates) which you can use to help you get started writing your templates of your own. 
       
 
@@ -106,10 +106,10 @@ templates-repository/
    ├─ skeleton/
 ```
 
-!!! note "About The Skeletons..."
-    The skeleton directory contains a template codebase that the [Backstage scaffolder (template engine)(https://backstage.io/docs/features/software-templates/writing-templates/)] will process using Nunjucks (more on this later) if you're using the `fetch:template` action. Samples are available upstream in [backstage/software-templates Git repository](https://github.com/backstage/software-templates/).
+!!! tip "About The Skeletons..."
+    The `skeleton` directory contains a template codebase that the [Backstage scaffolder (template engine)](https://backstage.io/docs/features/software-templates/writing-templates/) will process using Nunjucks (more on this later) if you're using the `fetch:template` action. Samples are available upstream in [backstage/software-templates Git repository](https://github.com/backstage/software-templates/).
 
-The [Backstage templates repository(https://github.com/rhdh-demo-gh/templates/)] demonstrates a sample implementation of this pattern. Organizations that need more granular control over template authorship and access might choose to create additional template repositories that split templates by knowledge domain or organizational boundaries.
+The [Backstage templates repository](https://github.com/rhdh-demo-gh/templates/) demonstrates a sample implementation of this pattern. Organizations that need more granular control over template authorship and access might choose to create additional template repositories that split templates by knowledge domain or organizational boundaries.
 
 Red Hat Developer Hub also has a [free library of software templates](https://github.com/redhat-developer/red-hat-developer-hub-software-templates) which you can use to help you get started writing your templates of your own. 
 
@@ -128,7 +128,7 @@ You can use the Template Editor to:
 
 This page allows experimenting with edits to a template, and seeing the changes rendered on the right. Once you're happy with the changes, you can copy them to your `template.yaml`.
 
-[Open The Template Editor Menu](/create/edit){ .md-button }
+[Open The Template Editor Menu](/create/edit){ .md-button .md-button--primary }
 
 ## Tip #3: Explore Installed Actions
 
@@ -138,7 +138,7 @@ For example, if the Quay Plugin is installed, it can be referenced in a template
 
 Use the Installed Actions page to understand the actions that are available to template authors in your Backstage instance.
 
-[View The Installed Template Actions](/create/actions){ .md-button }
+[View The Installed Template Actions](/create/actions){ .md-button .md-button--primary }
 
 ## Tip #4: Improve DevEx Using Custom Field Extensions
 

--- a/configs/catalog-entities/docs/ten_template_tips.md
+++ b/configs/catalog-entities/docs/ten_template_tips.md
@@ -1,0 +1,274 @@
+Adapted from the original [Red Hat Developer blog post by *Evan Shortiss*](https://developers.redhat.com/articles/2025/03/17/10-tips-better-backstage-software-templates)
+
+After deploying Red Hat Developer Hub as your internal developer portal (IDP), adding Software Templates is an essential step. Software Templates transform IDPs into the self-service productivity powerhouse your developers deserve. This article provides essential insights and some advanced tips to help you craft better Software Templates and boost your developer productivity.
+
+## Templating Fundamentals
+
+Software Templates tell Backstage how to automate chores. Platform engineers can craft templates to enable developer self-service. For example, a developer could use a project or team's custom template to provision cloud resources or create a new Git repository. The template makes it easier for the developer and it ensures resources, skeleton code, and deployment targets adhere to the organization's best practices for creating microservices, configuring CI/CD, and enforcing security.
+
+So, how does this work? Software Templates are defined in YAML, like everything else in this cloud-native world we live in. The key elements of a template are the parameters and steps that define the inputs and actions [Backstage's scaffolder (template engine)](https://backstage.io/docs/features/software-templates/writing-templates/) will request and execute. Figure 1 demonstrates an example of a flow that a developer goes through when utilizing a template to create a new application.
+
+The following YAML illustrates how it works. The YAML creates a Java microservice codebase based on an existing template, stores it in a Git repository with the given name, and displays the URL to the newly created repository when finished. A platform engineer will load this template into Backstage either using the UI or by adding a link to it in the [catalog section of the Backstage configuration file](https://backstage.io/docs/features/software-catalog/configuration/).
+
+```yaml
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: create-java-microservice
+  title: Java Microservice
+  description: Creates a Java Microservice that follows best practices
+spec:
+  owner: platform-engineering
+  type: microservice
+  parameters:
+    - title: Name
+      required:
+        - name
+      properties:
+        name:
+          title: Name
+          type: string
+          description: Unique name for the Component, and repository
+          maxLength: 50
+          pattern: '^([a-zA-Z][a-zA-Z0-9]*)(-[a-zA-Z0-9]+)*$'
+          ui:autofocus: true
+  steps:
+    - id: generateSource
+      name: Generate Application Codebase
+      action: fetch:template
+      input:
+        # Template code location
+        url: https://github.com/your-org/template-codebases/java-microservice
+        # Local directory used to store generated code
+        targetPath: ./source
+        # Variables passed to Nunjucks when it renders the
+        # new files in the source folder from the template
+        values:
+          name: ${{ parameters.name }}
+    - id: publishSource
+      name: Create Source Code Repository on GitHub
+      action: publish:github
+      input:
+        allowedHosts: ['github.com']
+        description: ${{ parameters.description }}
+        repoUrl: github.com?owner=your-org&repo=${{ parameters.name }}
+        defaultBranch: main
+        sourcePath: ./source
+  output:
+    links:
+      - title: View the Source Repository
+        url: ${{ steps.publishSource.output.remoteUrl }}
+```
+
+Software Templates can do much more than simply bootstrap Git repositories. Creative platform engineering teams can write templates that provision cloud resources using GitOps, trigger CI pipelines, open PRs to request approvals and much more. Take a look at the [RHDH Extensions Catalog](/extensions?filter=spec.categories%3DScaffolder) to find plugins that expose scaffolder actions you can utilize to create your own templates.
+
+!!! note "Free Software Template Samples"
+    Red Hat Developer Hub has a [free library of software templates](https://github.com/redhat-developer/red-hat-developer-hub-software-templates) which you can use to help you get started writing your templates of your own. 
+      
+
+## 10 Backstage Template Tips
+
+Now we're on the same page, here are my top 10 tips for improving your Backstage Software Templates:
+
+1. Structuring your template repository
+2. Experimenting with the template editor
+3. Exploring installed actions 
+4. Improving DevEx using custom field extensions
+5. Processing structured data using template filters
+6. Using the Nunjucks API
+7. Protecting Secrets
+8. Specifying the template type and tags
+9. Documenting your templates
+10. Planning for maintenance
+
+Use the links in the sidebar to skip ahead.
+
+## Tip #1: Structure Your Template Repository
+
+Like everything in Backstage, Software Templates are entities (the YAML you reviewed in the prior section) that are imported into the software catalog. Generally speaking, the YAML representing templates is stored in a Git repository. Platform engineers configure their Backstage instance to import the templates.
+
+An organization beginning its journey with internal developer portals and platform engineering is best served by creating a central repository to store templates. Popular convention stores each `template.yaml` in a subfolder with its assets and documentation. A `location.yaml` at the root of the repository can use a Location Entity with glob pattern to instruct Backstage to import templates from each subfolder.
+
+This pattern reduces the repetitive task of importing each new template to the Backstage instance individually by simply committing the new template. Then it will appear in the software catalog within a few minutes once the `location.yaml` is referenced in your Backstage catalog configuration.
+
+```text
+templates-repository/
+├─ location.yaml
+├─ nodejs-backend/
+│  ├─ template.yaml
+│  ├─ README.md
+│  └─ skeleton/
+├─ react-frontend/
+│  ├─ template.yaml
+│  ├─ skeleton/
+└─ java-microservice/
+   ├─ template.yaml
+   ├─ skeleton/
+```
+
+!!! note "About The Skeletons..."
+    The skeleton directory contains a template codebase that the [Backstage scaffolder (template engine)(https://backstage.io/docs/features/software-templates/writing-templates/)] will process using Nunjucks (more on this later) if you're using the `fetch:template` action. Samples are available upstream in [backstage/software-templates Git repository](https://github.com/backstage/software-templates/).
+
+The [Backstage templates repository(https://github.com/rhdh-demo-gh/templates/)] demonstrates a sample implementation of this pattern. Organizations that need more granular control over template authorship and access might choose to create additional template repositories that split templates by knowledge domain or organizational boundaries.
+
+Red Hat Developer Hub also has a [free library of software templates](https://github.com/redhat-developer/red-hat-developer-hub-software-templates) which you can use to help you get started writing your templates of your own. 
+
+## Tip #2: Experiment Using the Template Editor
+
+Pushing changes to a template repository, waiting for Backstage to synchronize the changes, and then doing a test run of changes is an inefficient development loop. A better approach is to use the Template Editor included in Backstage, and by extension, Red Hat Developer Hub.
+
+The template editor can be accessed by visiting the `/create/edit` page directly, or by using the Template Editor link on the Software Templates page.
+
+You can use the Template Editor to:
+
+- Edit templates stored in a directory on your development machine (or one that you copy/paste into the editor).
+- Edit a sample template.
+- Experiment with edits to existing templates in your Backstage instance.
+- Experiment with installed Custom Field Extensions (more on these in a moment).
+
+This page allows experimenting with edits to a template, and seeing the changes rendered on the right. Once you're happy with the changes, you can copy them to your `template.yaml`.
+
+## Tip #3: Explore Installed Actions
+
+As mentioned earlier, Backstage includes built-in actions and supports actions provided by plugins. You can view available actions and their inputs and outputs by visiting the Installed Actions page via the Software Catalog or the `/create/actions` page directly.
+
+For example, if the Quay Plugin is installed, it can be referenced in a template using the action: `quay:create-repository` syntax, expects `name`, `visibility`, `description`, and `token` input parameters as shown in this view.
+
+Use the Installed Actions page to understand the actions that are available to template authors in your Backstage instance.
+
+## Tip #4: Improve DevEx Using Custom Field Extensions
+
+Forms rendered based on Software Templates are powered by [react-jsonschema-form (rjsf)](https://github.com/rjsf-team/react-jsonschema-form). This provides platform engineers with a great deal of flexibility in how they collect the input parameters for their templates. However, Backstage also provides a [Custom Field Extensions API](https://backstage.io/docs/features/software-templates/writing-custom-field-extensions/) that enables platform engineers to further enrich their templates with custom inputs.
+
+If you're wondering why this might be necessary, consider a scenario where a template asks a user to assign an owner to a new component. Manually typing the group name is error-prone, so the platform engineer uses the built-in [OwnerPicker Custom Field Extension](https://backstage.io/docs/features/software-templates/ui-options-examples/#ownerpicker) to present a dropdown that contains valid options.
+
+## Tip #5: Process Structured Data Using Template Filters
+
+Backstage [Template Filters](https://backstage.io/docs/features/software-templates/template-extensions) are functions that operate on objects in your templates. For example, consider the previous custom field extensions that return [Entity References as strings](https://backstage.io/docs/features/software-catalog/references#string-references). A template might collect a reference to a component using an EntityPicker field as follows:
+
+```yaml
+properties:
+  component:
+    title: Component
+    type: string
+    description: The Component you wish to deploy
+    ui:field: EntityPicker
+    ui:options:
+      allowArbitraryValues: false
+      catalogFilter:
+        kind: Component
+```
+
+The resulting value of `${{ params.component }}` will have the format `component:namespace/component-name`. Actions in the template can use the [`parseEntityRef`](https://backstage.io/docs/reference/catalog-model.parseentityref/) filter to extract properties from the entity reference, such as the namespace or name, as follows.
+
+```yaml
+id: openPullRequest
+name: Create Pull Request
+action: publish:github:pull-request
+input:
+  repoUrl: github.com?repo=your-repo&owner=your-org
+  title: "Update for ${{ parameters.component | parseEntityRef | prop('name') }}"
+  commitMessage: "Adds some amazing new functionality"
+  sourcePath: ./
+  targetPath: ./${{ parameters.component | parseEntityRef | prop('name') }}
+```
+
+There is a complete example of using `parseEntityRef` in [this sample template](https://github.com/rhdh-demo-gh/templates/blob/c8182d34f5550a1dc2c1fd25e67298b7ea9721eb/deploy-component/template.yaml).
+
+## Tip #6: Use the Nunjucks API
+
+As previously discussed, templates that use the `fetch:template` action can generate content based on a skeleton. All files in the skeleton are processed using the [Nunjucks templating language](https://mozilla.github.io/nunjucks/templating.html). Values can be passed to the skeleton by passing values as inputs to the `fetch:template` action.
+
+```yaml
+id: generateSource
+name: Generate Next.js Application
+action: fetch:template
+input:
+  # The skeleton folder is in the same repository and folder
+  # as this template.yaml file, so a relative path works!
+  url: ./skeleton
+  targetPath: ./source
+  values:
+    name: ${{ parameters.name }}
+    owner: ${{ parameters.owner }}
+    system: ${{ parameters.system }}
+    description: ${{ parameters.description }}
+```
+
+These values can be used in skeleton files by accessing the values object. For example, the name can be injected using the `${{ values.name }}` syntax, as seen in this [example package.json](https://github.com/rhdh-demo-gh/templates/blob/c8182d34f5550a1dc2c1fd25e67298b7ea9721eb/nextjs/skeleton/package.json#L2).
+
+However, replacing values is the most basic functionality provided. Nunjucks provides tags to perform operations on your templates. Tags such as `if` and `for` can be used to implement conditional logic based on user provided properties and iterating over values. The `raw` tag can be used to preserve blocks of content. A common scenario where `raw` is useful is when you need to preserve content as-is, such as [variables in a GitHub Actions workflow](https://github.com/rhdh-demo-gh/templates/blob/c8182d34f5550a1dc2c1fd25e67298b7ea9721eb/nextjs/skeleton/.github/workflows/build.yaml#L30-L34). Failure to use `raw` would result in empty values replacing the values in the following example, instead of preserving these values per the template author's intent.
+
+```yaml
+- name: Log in to the Container registry
+  uses: docker/login-action@v3
+  with:
+    {% raw %}
+    registry: ${{ env.REGISTRY }}
+    username: ${{ github.repository_owner }}
+    password: ${{ secrets.GITHUB_TOKEN }}
+    {% endraw %}
+```
+
+## Tip #7: Protect Secrets
+
+Collecting sensitive data, such as a password or authentication token, as a template parameter needs to be handled carefully. While it might be tempting to use a regular text input field, the correct approach is to use the [Secret field provided by Backstage](https://backstage.io/docs/features/software-templates/writing-templates/#using-secrets).
+
+You may want to mark things as secret and make sure that these values are protected and not available through REST endpoints. You can do this by using the built in `ui:field: Secret`. You can define this property as any normal parameter, however the consumption of this parameter will not be available through `${{ parameters.myKey }}` you will instead need to use `${{ secrets.myKey }}` in your `template.yaml`.
+
+```yaml
+  password:
+    type: string
+    ui:field: Secret
+```
+
+The Secret field ensures that the value entered by the end-user in Backstage is masked. Additionally, the value is masked in logs and the Review screen before the the scaffolder processes the template. This prevents inadvertent leaking of credentials.
+
+## Tip #8: Specify the Template Type and Tags
+
+The Software Templates screen in Backstage lists all available templates by default. As you might imagine, this screen will become cluttered if you have multiple templates available.
+
+Specifying a template's `spec.type` is required, but most examples use the default value of `service` – thoughtfully set the type to organize templates in categories. Similarly, make use of `metadata.tags` to further classify templates into subcategories.
+
+## Tip #9: Document Your Templates
+
+Well-designed templates should be intuitive. Nevertheless, high-quality documentation makes self-service easier for developers with examples and an overview of what a template does.
+
+Enabling a [production-ready configuration for TechDocs](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/customizing/configuring-techdocs#configuring-techdocs) on your Backstage or Red Hat Developer Hub instance requires object storage, but for the purpose of testing, you can use the following config:
+
+```yaml
+techdocs:
+  builder: 'local'
+  publisher:
+    type: 'local'
+  generator:
+    runIn: local
+```
+
+With TechDocs enabled, add `backstage.io/techdocs-ref` annotation to the `template.yaml`, then create a `mkdocs.yaml` and a `docs/index.md` file relative to the `template.yaml`. A complete example is available in [this GitHub repository](https://github.com/rhdh-demo-gh/templates/tree/main/deploy-component).
+
+Once everything is in place, you can view the TechDocs for your template in your internal developer portal alongside your other TechDocs.
+
+## Tip #10: Plan for Maintenance
+
+Software Templates open up exciting possibilities, but using them effectively requires a commitment to long-term support and maintenance.
+
+Imagine a developer's frustration if they scaffold a new application using your template only for it to immediately throw an error, or if they create a code that uses an outdated version of a key framework that contains critical security vulnerabilities that have since been patched.
+
+Software Templates are supposed to codify your best practices and enhance developer productivity, so failure to keep your templates up to date will send the wrong message and undermine their value. Like regular software applications, you'll need to update your templates to ensure they continue to work well. Be sure to avoid scaffolding code repositories with outdated code or dependencies.
+
+An outdated template is a liability, not an asset. Plan to regularly update your software templates, and consider implementing automated tests using the scaffolder HTTP API endpoints to help you stay on top of things.
+
+## Bonus Tip: How to Accelerate the Development Loop
+
+A local Backstage instance shrinks the feedback loop for template developers. You can deploy Red Hat Developer Hub locally using the open-source [RHDH Local](https://github.com/redhat-developer/rhdh-local) project. Alternatively, you can replicate a production-like deployment by using the [Red Hat Developer Hub Operator](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/installing_red_hat_developer_hub_on_openshift_container_platform/assembly-install-rhdh-ocp-operator) or [Red Hat Developer Hub Helm Chart](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/installing_red_hat_developer_hub_on_openshift_container_platform/assembly-install-rhdh-ocp-helm) on [OpenShift Local](https://developers.redhat.com/products/openshift-local/overview).
+
+Additionally, the quarkus-backstage extension simplifies the process of running Backstage locally with Gitea. It provides a DevUI, Dev Service, and a Backstage API client to simplify integration testing of your templates and other entities.
+
+## Wrap Up
+
+Software Templates and internal developer portals facilitate developer self-service, leading to happier and more productive development teams. Now that you're equipped with my tips, you can craft experiences that empower your developers to innovate whilst following your organization's best-practices. 
+
+## Additional Resources
+
+Read [Get started with Red Hat Developer Hub on OpenShift](https://developers.redhat.com/articles/2024/11/25/red-hat-developer-hub-fastest-path-backstage-kubernetes#) to begin building your enterprise ready internal developer portal on OpenShift.

--- a/configs/catalog-entities/docs/ten_template_tips.md
+++ b/configs/catalog-entities/docs/ten_template_tips.md
@@ -117,7 +117,7 @@ Red Hat Developer Hub also has a [free library of software templates](https://gi
 
 Pushing changes to a template repository, waiting for Backstage to synchronize the changes, and then doing a test run of changes is an inefficient development loop. A better approach is to use the Template Editor included in Backstage, and by extension, Red Hat Developer Hub.
 
-The template editor can be accessed by visiting the `/create/edit` page directly, or by using the Template Editor link on the Software Templates page.
+The template editor can be accessed by visiting the [`/create/edit`](/create/edit) page directly, or by using the Template Editor link on the Software Templates page.
 
 You can use the Template Editor to:
 
@@ -130,7 +130,7 @@ This page allows experimenting with edits to a template, and seeing the changes 
 
 ## Tip #3: Explore Installed Actions
 
-As mentioned earlier, Backstage includes built-in actions and supports actions provided by plugins. You can view available actions and their inputs and outputs by visiting the Installed Actions page via the Software Catalog or the `/create/actions` page directly.
+As mentioned earlier, Backstage includes built-in actions and supports actions provided by plugins. You can view available actions and their inputs and outputs by visiting the Installed Actions page via the Software Catalog or the [`/create/actions`](/create/actions) page directly.
 
 For example, if the Quay Plugin is installed, it can be referenced in a template using the action: `quay:create-repository` syntax, expects `name`, `visibility`, `description`, and `token` input parameters as shown in this view.
 

--- a/configs/catalog-entities/docs/ten_template_tips.md
+++ b/configs/catalog-entities/docs/ten_template_tips.md
@@ -128,6 +128,8 @@ You can use the Template Editor to:
 
 This page allows experimenting with edits to a template, and seeing the changes rendered on the right. Once you're happy with the changes, you can copy them to your `template.yaml`.
 
+[Open The Template Editor Menu](/create/edit){ .md-button }
+
 ## Tip #3: Explore Installed Actions
 
 As mentioned earlier, Backstage includes built-in actions and supports actions provided by plugins. You can view available actions and their inputs and outputs by visiting the Installed Actions page via the Software Catalog or the [`/create/actions`](/create/actions) page directly.
@@ -135,6 +137,8 @@ As mentioned earlier, Backstage includes built-in actions and supports actions p
 For example, if the Quay Plugin is installed, it can be referenced in a template using the action: `quay:create-repository` syntax, expects `name`, `visibility`, `description`, and `token` input parameters as shown in this view.
 
 Use the Installed Actions page to understand the actions that are available to template authors in your Backstage instance.
+
+[View The Installed Template Actions](/create/actions){ .md-button }
 
 ## Tip #4: Improve DevEx Using Custom Field Extensions
 
@@ -272,3 +276,5 @@ Software Templates and internal developer portals facilitate developer self-serv
 ## Additional Resources
 
 Read [Get started with Red Hat Developer Hub on OpenShift](https://developers.redhat.com/articles/2024/11/25/red-hat-developer-hub-fastest-path-backstage-kubernetes#) to begin building your enterprise ready internal developer portal on OpenShift.
+
+*[RHDH]: Red Hat Developer Hub

--- a/configs/catalog-entities/docs/ten_template_tips.md
+++ b/configs/catalog-entities/docs/ten_template_tips.md
@@ -267,7 +267,7 @@ An outdated template is a liability, not an asset. Plan to regularly update your
 
 A local Backstage instance shrinks the feedback loop for template developers. You can deploy Red Hat Developer Hub locally using the open-source [RHDH Local](https://github.com/redhat-developer/rhdh-local) project. Alternatively, you can replicate a production-like deployment by using the [Red Hat Developer Hub Operator](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/installing_red_hat_developer_hub_on_openshift_container_platform/assembly-install-rhdh-ocp-operator) or [Red Hat Developer Hub Helm Chart](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/installing_red_hat_developer_hub_on_openshift_container_platform/assembly-install-rhdh-ocp-helm) on [OpenShift Local](https://developers.redhat.com/products/openshift-local/overview).
 
-Additionally, the quarkus-backstage extension simplifies the process of running Backstage locally with Gitea. It provides a DevUI, Dev Service, and a Backstage API client to simplify integration testing of your templates and other entities.
+Additionally, the [quarkus-backstage](https://github.com/quarkiverse/quarkus-backstage) extension simplifies the process of running Backstage locally with Gitea. It provides a DevUI, Dev Service, and a Backstage API client to simplify integration testing of your templates and other entities.
 
 ## Wrap Up
 

--- a/configs/catalog-entities/mkdocs.yml
+++ b/configs/catalog-entities/mkdocs.yml
@@ -7,6 +7,8 @@ plugins:
 nav:
   - "Welcome To RHDH Local": index.md
   - "Highlights Of Red Hat Developer Hub": features.md
-  - "TechDocs Extensions": extensions.md
+  - "Comparing Red Hat Developer Hub to CNCF Backstage": comparison.md
+  - "Making Your TechDocs More Appealing": extensions.md
+
 
   

--- a/configs/catalog-entities/mkdocs.yml
+++ b/configs/catalog-entities/mkdocs.yml
@@ -12,5 +12,6 @@ plugins:
 nav:
   - "Welcome To Red Hat Developer Hub": index.md
   - "Highlights Of Red Hat Developer Hub": features.md
+  - "TechDocs Extensions": extensions.md
 
   

--- a/configs/catalog-entities/mkdocs.yml
+++ b/configs/catalog-entities/mkdocs.yml
@@ -1,10 +1,5 @@
-# site_name: backstage
-# docs_dir: docs
-# plugins:
-#   - techdocs-core
-
-site_name: red-hat-developer-hub
-site_description: Red Hat Developer Hub
+site_name: rhdh-local
+site_description: RHDH Local
 site_author: user:user
 docs_dir: docs
 plugins:

--- a/configs/catalog-entities/mkdocs.yml
+++ b/configs/catalog-entities/mkdocs.yml
@@ -10,7 +10,7 @@ docs_dir: docs
 plugins:
   - techdocs-core
 nav:
-  - "Welcome To Red Hat Developer Hub": index.md
+  - "Welcome To RHDH Local": index.md
   - "Highlights Of Red Hat Developer Hub": features.md
   - "TechDocs Extensions": extensions.md
 

--- a/configs/catalog-entities/mkdocs.yml
+++ b/configs/catalog-entities/mkdocs.yml
@@ -9,6 +9,7 @@ nav:
   - "Highlights Of Red Hat Developer Hub": features.md
   - "Comparing Red Hat Developer Hub to CNCF Backstage": comparison.md
   - "Making Your TechDocs More Appealing": extensions.md
+  - "Top 10 Tips For Better Software Templates": ten_template_tips.md
 
 
   


### PR DESCRIPTION
## Description

Updates to RHDH Local TechDocs to add a comparison page. This page allows users to better understand the differences between RHDH and CNCF Backstage.

## Which issue(s) does this PR fix or relate to

n/a

## PR acceptance criteria

- [ x] Documentation

## How to test changes / Special notes to the reviewer

Start RHDH Local and if TechDocs is configured take a look at the "RHDH Local" entry.
