### PR TITLE
fix dynamic-plugins.override.example.yaml

### DIFF
--- a/configs/dynamic-plugins/dynamic-plugins.override.example.yaml
+++ b/configs/dynamic-plugins/dynamic-plugins.override.example.yaml
@@ -6,7 +6,7 @@ includes:
 
 # Below you can add custom dynamic plugins, including local ones.
 plugins:
-  - package: local-plugins/example-plugin
+  - package: ./local-plugins/example-plugin
     disabled: false
     pluginConfig:
       # Optional: Configuration passed to your plugin


### PR DESCRIPTION
Local path needs to start with ./ otherwise it fails non existing sha checksum 