### PR TITLE
[WIP] feat: add frontend plugin dev guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 configs/github-app-credentials.yaml
 configs/.npmrc
 /tmp
+dynamic-plugins-root
 
 # User-specific local configuration files
 *.local.yaml

--- a/README.md
+++ b/README.md
@@ -278,67 +278,9 @@ If you want to use PostgreSQL with RHDH, here are the steps:
    #   connection: ':memory:'
    ```
 
-## Developers: Using VSCode to debug backend plugins
-
-You can use RHDH-local with a debugger to to debug your backend plugins in VSCode. Here is how:
-
-1. Start RHDH-local with the "debug" compose file
-
-   ```sh
-   # in rhdh-local directory
-   podman-compose up -f compose.yaml -f compose-debug.yaml
-   ```
-
-2. Open your plugin source code in VSCode
-3. Export plugin an RHDH "dynamic" plugin
-
-   ```sh
-   # in plugin source code directory
-   npx @janus-idp/cli@latest package export-dynamic-plugin
-   ```
-
-4. Copy exported derived plugin package to `dynamic-plugins-root` directory in the `rhdh` container.
-
-   ```sh
-   # in plugin source code directory
-   podman cp dist-dynamic rhdh:/opt/app-root/src/dynamic-plugins-root/<your-plugin-name>
-   ```
-
-5. If your plugin requires configuration, add it to the `app-config.local.yaml` file in your cloned `rhdh-local` directory.
-
-6. Restart the `rhdh` container
-
-   ```sh
-   # in rhdh-local directory
-   podman-compose stop rhdh
-   podman-compose start rhdh
-   ```
-
-7. Configure VSCode debugger to attach to the `rhdh` container.
-
-   `.vscode/launch.json` example:
-
-   ```json
-   {
-      "version": "0.2.0",
-      "configurations": [
-         {
-            "name": "Attach to Process",
-            "type": "node",
-            "request": "attach",
-            "port": 9229,
-            "localRoot": "${workspaceFolder}",
-            "remoteRoot": "/opt/app-root/src/dynamic-plugins-root/<your-plugin-name>",
-         }
-      ]
-   }
-   ```
-
-8. Now, you can start debugging your plugin using VSCode debugger.
-   Source mapping should work, and you should be able to put breakpoints to your TypeScript files.
-   If it doesn't work, most likely you need to adjust `localRoot` and `remoteRoot` paths in `launch.json`.
-
-   Every time you make changes to your plugin source code, you need to repeat steps 3-6.
+## For plugin Developers
+- [Using VSCode to debug backend plugins](docs/plugin-development/debugging.md)
+- [Frontend Plugin Development](docs/plugin-development/frontend-development.md)
 
 ## Configuring Registry Credentials
 

--- a/compose-dynamic-plugins-root.yaml
+++ b/compose-dynamic-plugins-root.yaml
@@ -15,8 +15,6 @@ services:
       - type: bind
         source: ./dynamic-plugins-root
         target: /opt/app-root/src/dynamic-plugins-root
-        volume:
-          nocopy: true
 
 
   install-dynamic-plugins:
@@ -24,5 +22,3 @@ services:
       - type: bind
         source: ./dynamic-plugins-root
         target: /dynamic-plugins-root
-        volume:
-          nocopy: true

--- a/compose-dynamic-plugins-root.yaml
+++ b/compose-dynamic-plugins-root.yaml
@@ -1,0 +1,28 @@
+# This Compose file is not usable on its own.
+# It needs to be used alongside the default compose.yaml file,
+# since it overrides the containers defined in the latter.
+#
+# You can run `[podman|docker] compose -f compose.yaml -f compose-dynamic-plugins-root.yaml config`
+# to view the effective merged config.
+
+# WARNING: this file currently only works with Docker Compose. 
+# Issue with Podman Compose: https://github.com/containers/podman-compose/issues/1204
+
+
+services:
+  rhdh:
+    volumes:
+      - type: bind
+        source: ./dynamic-plugins-root
+        target: /opt/app-root/src/dynamic-plugins-root
+        volume:
+          nocopy: true
+
+
+  install-dynamic-plugins:
+    volumes:
+      - type: bind
+        source: ./dynamic-plugins-root
+        target: /dynamic-plugins-root
+        volume:
+          nocopy: true

--- a/docs/plugin-development/debugging-backend.md
+++ b/docs/plugin-development/debugging-backend.md
@@ -1,0 +1,61 @@
+# Using VSCode to debug backend plugins
+
+You can use RHDH-local with a debugger to to debug your backend plugins in VSCode. Here is how:
+
+1. Start RHDH-local with the "debug" compose file
+
+   ```sh
+   # in rhdh-local directory
+   podman-compose up -f compose.yaml -f compose-debug.yaml
+   ```
+
+2. Open your plugin source code in VSCode
+3. Export plugin an RHDH "dynamic" plugin
+
+   ```sh
+   # in plugin source code directory
+   npx @janus-idp/cli@latest package export-dynamic-plugin
+   ```
+
+4. Copy exported derived plugin package to `dynamic-plugins-root` directory in the `rhdh` container.
+
+   ```sh
+   # in plugin source code directory
+   podman cp dist-dynamic rhdh:/opt/app-root/src/dynamic-plugins-root/<your-plugin-name>
+   ```
+
+5. If your plugin requires configuration, add it to the `app-config.local.yaml` file in your cloned `rhdh-local` directory.
+
+6. Restart the `rhdh` container
+
+   ```sh
+   # in rhdh-local directory
+   podman-compose stop rhdh
+   podman-compose start rhdh
+   ```
+
+7. Configure VSCode debugger to attach to the `rhdh` container.
+
+   `.vscode/launch.json` example:
+
+   ```json
+   {
+      "version": "0.2.0",
+      "configurations": [
+         {
+            "name": "Attach to Process",
+            "type": "node",
+            "request": "attach",
+            "port": 9229,
+            "localRoot": "${workspaceFolder}",
+            "remoteRoot": "/opt/app-root/src/dynamic-plugins-root/<your-plugin-name>",
+         }
+      ]
+   }
+   ```
+
+8. Now, you can start debugging your plugin using VSCode debugger.
+   Source mapping should work, and you should be able to put breakpoints to your TypeScript files.
+   If it doesn't work, most likely you need to adjust `localRoot` and `remoteRoot` paths in `launch.json`.
+
+   Every time you make changes to your plugin source code, you need to repeat steps 3-6.

--- a/docs/plugin-development/frontend-development.md
+++ b/docs/plugin-development/frontend-development.md
@@ -1,0 +1,35 @@
+# Frontend Plugin Development
+
+Follow these steps to preview and test development changes for your frontend plugin in RHDH local:
+
+1. Ensure a clean start by running the following command:
+
+   ```shell
+   podman compose down -v
+   ```
+
+2. Use the `compose-dynamic-plugins-root.yaml` override file to start RHDH local.
+
+   ```shell
+   podman compose -f compose.yaml -f compose-dynamic-plugins-root.yaml up
+   ```
+
+   This command will create a `dynamic-plugins-root` directory in your current working directory. You will place your exported plugin files in this directory.
+
+3. Add the plugin configuration for the plugin you want to develop into the `app-config.local.yaml` file under the `dynamicPlugins` key. Avoid adding this configuration to the `dynamic-plugins.override.yaml` file. You can add additional plugins into the `dynamic-plugins.override.yaml` file, but the one you are developing should be in the `app-config.local.yaml` file.
+
+4. Inside your plugin directory, run the following command to export your plugin:
+
+   ```shell
+   npx @janus-idp/cli@latest package export-dynamic-plugin --dev --dynamic-plugins-root <path_to_dynamic-plugins-root_in_rhdh-local_folder>
+   ```
+
+5. Restart the RHDH container to apply changes:
+
+   ```shell
+   podman compose stop rhdh && podman compose start rhdh
+   ```
+
+6. Verify that your plugin appears in RHDH.
+
+7. To apply code changes to your plugin, rerun the command in step 4 and refresh your browser. No need to restart any containers.


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
- Add new compose file variant that exposes dynamic-plugins-root folder, which allows sideload dynamic plugins.
- Add documentation on how to use rhdh local to develop frontend plugin


> [!CAUTION]  
> This currently doesn't work with podman compose due to https://github.com/containers/podman-compose/issues/1204 
> We need to find workaround before we can merge this

## PR acceptance criteria

- [ ] Tests
- [x] Documentation

