### PR TITLE
chore: Fix refs to deprecated janus-idp

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ This image supports both `amd64` and `arm64`.
    docker compose up -d
    ```
 
+3. Open [http://localhost:7007](http://localhost:7007) in your browser to access RHDH.
+
 ## Changing Your Configuration
 
 When you change `app-config.local.yaml` you must restart the `rhdh` container to load RHDH your updated configuration.

--- a/README.md
+++ b/README.md
@@ -143,18 +143,18 @@ If you don't create a `.npmrc`, plugin installation will still work using the de
 
 ## Changing The Container Image
 
-You can switch between RHDH and Janus-IDP by changing the container image name hold by the `RHDH_IMAGE` environment variable in your `.env` file.
+You can switch between the [downstream](https://quay.io/repository/rhdh/rhdh-hub-rhel9?tab=tags) and [community](https://quay.io/repository/rhdh-community/rhdh?tab=tags) versions of RHDH by changing the container image name hold by the `RHDH_IMAGE` environment variable in your `.env` file.
 
-To use nightly build of Janus-IDP, set the variable as follows:
+For example, to use the nightly community build, set the variable as follows:
 
 ```sh
-RHDH_IMAGE=quay.io/janus-idp/backstage-showcase:next
+RHDH_IMAGE=quay.io/rhdh-community/rhdh:next
 ```
 
-To use the official release of RHDH 1.4, set the variable as follows:
+To use the official release of RHDH 1.y, set the variable as follows (replace `y` accordingly):
 
 ```sh
-RHDH_IMAGE=quay.io/rhdh/rhdh-hub-rhel9:1.4
+RHDH_IMAGE=quay.io/rhdh/rhdh-hub-rhel9:1.y
 ```
 
 ## Testing RHDH in a simulated corporate proxy setup
@@ -199,7 +199,7 @@ podman system prune --volumes # For rhdh-local running on podman
 
 ### Known Issues when using Podman Compose
 
-Works with `podman-compose` only with image that include this following fix https://github.com/janus-idp/backstage-showcase/pull/1585
+Works with `podman-compose` only with images that include this following fix https://github.com/redhat-developer/rhdh/pull/1585
 
 Older images don't work in combination with `podman-compose`.
 This is due to https://issues.redhat.com/browse/RHIDP-3939. RHDH images currently populate dynamic-plugins-root directory with all plugins that are packaged inside the image.

--- a/configs/catalog-entities/docs/index.md
+++ b/configs/catalog-entities/docs/index.md
@@ -11,7 +11,7 @@ Some of the worlds largest companies use Red Hat Developer Hub to:
 
 !!! tip "RHDH Proudly Based On CNCF Backstage"
 
-    Developer Hub is based on [Backstage](https://backstage.io) the open-source Internal Developer Portal (IDP) created by Spotify and donated to the Cloud Native Computing Foundation (CNCF). CNCF Backstage enjoys a vibrant user community and a fast growing ecosystem of useful extensions called "[plugins](https://developers.redhat.com/rhdh/plugins "plugins")". Many leading platform vendors (including  Red Hat) are contributing [code](https://github.com/janus-idp "source code") to the Backstage project to ensure the developer experience is as rich and rewarding as possible.
+    Developer Hub is based on [Backstage](https://backstage.io) the open-source Internal Developer Portal (IDP) created by Spotify and donated to the Cloud Native Computing Foundation (CNCF). CNCF Backstage enjoys a vibrant user community and a fast growing ecosystem of useful extensions called "[plugins](https://developers.redhat.com/rhdh/plugins "plugins")". Many leading platform vendors (including  Red Hat) are contributing [code](https://github.com/redhat-developer/rhdh "source code") to the [Backstage project](https://github.com/backstage/backstage) to ensure the developer experience is as rich and rewarding as possible.
 
 *[IDP]: Internal Developer Platform - a system intended to make iy easier to develop, secure, operate, and manage applications running on your cloud infrastructure.
 *[CNCF]: Cloud Native Computing Foundation

--- a/configs/dynamic-plugins/dynamic-plugins.yaml
+++ b/configs/dynamic-plugins/dynamic-plugins.yaml
@@ -59,12 +59,12 @@ plugins: []
   #     lifecycle: { timeToLive: { weeks: 2 } }
 
   # # loading plugin from directory inside the RHDH container
-  # - package: ./dynamic-plugins/dist/janus-idp-backstage-plugin-rbac
+  # - package: ./dynamic-plugins/dist/backstage-community-plugin-rbac
   #   disabled: true
   #   pluginConfig:
   #     dynamicPlugins:
   #       frontend:
-  #         janus-idp.backstage-plugin-rbac:
+  #         backstage-community.plugin-rbac:
   #           mountPoints:
   #             - mountPoint: admin.page.rbac/cards
   #               module: RbacPlugin


### PR DESCRIPTION
## Description
This PR removes/replaces references to janus-idp, especially in the README section on changing the container image.
The remaining reference to janus-idp is now the @janus-idp/cli tool for plugins:

```
README.md:   npx @janus-idp/cli@latest package export-dynamic-plugin
```

## Which issue(s) does this PR fix or relate to

Relates to https://issues.redhat.com/browse/RHIDP-1018

## PR acceptance criteria

- [ ] Tests
- [x] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
