### PR TITLE
Simplify README and compose files and FE dev guide

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,10 +35,10 @@ jobs:
         composeConfig:
           - name: "default"
             cliArgs: ""
-          - name: "debug"
-            cliArgs: "-f compose.yaml -f compose-debug.yaml"
           - name: "corporate-proxy"
             cliArgs: "-f compose.yaml -f compose-with-corporate-proxy.yaml"
+          - name: "dynamic-plugins-root"
+            cliArgs: "-f compose.yaml -f compose-dynamic-plugins-root.yaml"
 
     name: "${{ matrix.tool }} compose - ${{ matrix.composeConfig.name }}"
     runs-on: ubuntu-latest
@@ -90,6 +90,12 @@ jobs:
 
         # Custom app-config.local.yaml
         cp -vr configs/app-config/app-config.local.example.yaml configs/app-config/app-config.local.yaml
+
+    - name: Create dynamic plugins directory if needed
+      run: |
+        if [[ "${{ matrix.composeConfig.name }}" == "dynamic-plugins-root" ]]; then
+          mkdir -p dynamic-plugins-root
+        fi
 
     - name: Start app
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,9 +94,7 @@ jobs:
     - name: Create dynamic plugins directory
       if: ${{ matrix.composeConfig.name == "dynamic-plugins-root" }}
       run: |
-        if [[ "${{ matrix.composeConfig.name }}" == "dynamic-plugins-root" ]]; then
           mkdir -p dynamic-plugins-root
-        fi
 
     - name: Start app
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
         cp -vr configs/app-config/app-config.local.example.yaml configs/app-config/app-config.local.yaml
 
     - name: Create dynamic plugins directory
-      if: ${{ matrix.composeConfig.name == "dynamic-plugins-root" }}
+      if: ${{ matrix.composeConfig.name == 'dynamic-plugins-root' }}
       run: |
           mkdir -p dynamic-plugins-root
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,8 @@ jobs:
         # Custom app-config.local.yaml
         cp -vr configs/app-config/app-config.local.example.yaml configs/app-config/app-config.local.yaml
 
-    - name: Create dynamic plugins directory if needed
+    - name: Create dynamic plugins directory
+      if: ${{ matrix.composeConfig.name == "dynamic-plugins-root" }}
       run: |
         if [[ "${{ matrix.composeConfig.name }}" == "dynamic-plugins-root" ]]; then
           mkdir -p dynamic-plugins-root

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 configs/github-app-credentials.yaml
 configs/.npmrc
 /tmp
+dynamic-plugins-root
 
 # User-specific local configuration files
 *.local.yaml

--- a/README.md
+++ b/README.md
@@ -286,13 +286,13 @@ If you want to use PostgreSQL with RHDH, here are the steps:
 
 ## Developers: Using VSCode to debug backend plugins
 
-You can use RHDH-local with a debugger to to debug your backend plugins in VSCode. Here is how:
+You can use RHDH-local with a debugger to to debug your backend plugins in VSCode. The Node.js debugger is exposed on port 9229. Here is how:
 
-1. Start RHDH-local with the "debug" compose file
+1. Start RHDH-local
 
    ```sh
    # in rhdh-local directory
-   podman-compose up -f compose.yaml -f compose-debug.yaml
+   podman-compose up -d
    ```
 
 2. Open your plugin source code in VSCode

--- a/README.md
+++ b/README.md
@@ -346,6 +346,42 @@ You can use RHDH-local with a debugger to to debug your backend plugins in VSCod
 
    Every time you make changes to your plugin source code, you need to repeat steps 3-6.
 
+## Frontend Plugin Development
+
+Follow these steps to preview and test development changes for your frontend plugin in RHDH local:
+
+1. Ensure a clean start by running the following command:
+
+   ```shell
+   podman compose down -v
+   ```
+
+2. Use the `compose-dynamic-plugins-root.yaml` override file to start RHDH local.
+
+   ```shell
+   podman compose -f compose.yaml -f compose-dynamic-plugins-root.yaml up
+   ```
+
+   This command will create a `dynamic-plugins-root` directory in your current working directory. You will place your exported plugin files in this directory.
+
+3. Add the plugin configuration for the plugin you want to develop into the `app-config.local.yaml` file under the `dynamicPlugins` key. Avoid adding this configuration to the `dynamic-plugins.override.yaml` file. You can add additional plugins into the `dynamic-plugins.override.yaml` file, but the one you are developing should be in the `app-config.local.yaml` file.
+
+4. Inside your plugin directory, run the following command to export your plugin:
+
+   ```shell
+   npx @janus-idp/cli@latest package export-dynamic-plugin --dev --dynamic-plugins-root <path_to_dynamic-plugins-root_in_rhdh-local_folder>
+   ```
+
+5. Restart the RHDH container to apply changes:
+
+   ```shell
+   podman compose stop rhdh && podman compose start rhdh
+   ```
+
+6. Verify that your plugin appears in RHDH.
+
+7. To apply code changes to your plugin, rerun the command in step 4 and refresh your browser. No need to restart any containers.
+
 ## Configuring Registry Credentials
 
 Place your registry credentials in `./configs/extra-files`, then reference the auth file in your `.env`:

--- a/README.md
+++ b/README.md
@@ -356,31 +356,29 @@ Follow these steps to preview and test development changes for your frontend plu
    podman compose down -v
    ```
 
-2. Use the `compose-dynamic-plugins-root.yaml` override file to start RHDH local.
+2. Create the dynamic plugins root directory where you will place your exported plugins:
 
    ```shell
-   podman compose -f compose.yaml -f compose-dynamic-plugins-root.yaml up
+   mkdir dynamic-plugins-root
    ```
 
-   This command will create a `dynamic-plugins-root` directory in your current working directory. You will place your exported plugin files in this directory.
-
-3. Add the plugin configuration for the plugin you want to develop into the `app-config.local.yaml` file under the `dynamicPlugins` key. Avoid adding this configuration to the `dynamic-plugins.override.yaml` file. You can add additional plugins into the `dynamic-plugins.override.yaml` file, but the one you are developing should be in the `app-config.local.yaml` file.
-
-4. Inside your plugin directory, run the following command to export your plugin:
+3. Inside your plugin directory, run the following command to export your plugin:
 
    ```shell
    npx @janus-idp/cli@latest package export-dynamic-plugin --dev --dynamic-plugins-root <path_to_dynamic-plugins-root_in_rhdh-local_folder>
    ```
 
-5. Restart the RHDH container to apply changes:
+4. Add the plugin configuration for the plugin you want to develop into the `app-config.local.yaml` file under the `dynamicPlugins` key. Avoid adding this configuration to the `dynamic-plugins.override.yaml` file. You can add additional plugins into the `dynamic-plugins.override.yaml` file, but the one you are developing should be in the `app-config.local.yaml` file.
+
+5. Use the `compose-dynamic-plugins-root.yaml` override file to start RHDH local:
 
    ```shell
-   podman compose stop rhdh && podman compose start rhdh
+   podman compose -f compose.yaml -f compose-dynamic-plugins-root.yaml up
    ```
 
 6. Verify that your plugin appears in RHDH.
 
-7. To apply code changes to your plugin, rerun the command in step 4 and refresh your browser. No need to restart any containers.
+7. To apply code changes to your plugin, rerun the command in step 3 and refresh your browser. No need to restart any containers.
 
 ## Configuring Registry Credentials
 

--- a/README.md
+++ b/README.md
@@ -199,33 +199,6 @@ docker system prune --volumes # For rhdh-local running on docker
 podman system prune --volumes # For rhdh-local running on podman
 ```
 
-### Known Issues when using Podman Compose
-
-#### RHDH before 1.4.0
-
-Works with `podman-compose` only with images that include this following fix https://github.com/redhat-developer/rhdh/pull/1585
-
-Older images don't work in combination with `podman-compose`.
-This is due to https://issues.redhat.com/browse/RHIDP-3939. RHDH images currently populate dynamic-plugins-root directory with all plugins that are packaged inside the image.
-Before podman mounts volume over `dynamic-plugins-root` directory it copies all existing files into the volume. When the plugins are installed using `install-dynamic-plugins.sh` script it create duplicate installations of some plugins, this situation than prevents Backstage to start.
-
-#### Podman compose provider compatibility
-
-This also doesn't work with `podman compose` when using `docker-compose` as external compose provider on macOS.
-
-It fails with
-
-```
-install-dynamic-plugins-1  | Traceback (most recent call last):
-install-dynamic-plugins-1  |   File "/opt/app-root/src/install-dynamic-plugins.py", line 429, in <module>
-install-dynamic-plugins-1  |     main()
-install-dynamic-plugins-1  |   File "/opt/app-root/src/install-dynamic-plugins.py", line 206, in main
-install-dynamic-plugins-1  |     with open(dynamicPluginsFile, 'r') as file:
-install-dynamic-plugins-1  | PermissionError: [Errno 13] Permission denied: 'dynamic-plugins.yaml'
-```
-
-It looks like `docker-compose` when used with podman doesn't correctly propagate `Z` SElinux label.
-
 ## Using PostgreSQL database
 
 By default, in-memory db is used.
@@ -397,6 +370,16 @@ To report issues against this repository, please use [JIRA](https://issues.redha
 To browse the existing issues, you can use this [Query](https://issues.redhat.com/issues/?filter=-4&jql=project%20%3D%20%22Red%20Hat%20Internal%20Developer%20Platform%22%20%20AND%20component%20%3D%20%22RHDH%20Local%22%20AND%20resolution%20%3D%20Unresolved%20ORDER%20BY%20status%2C%20priority%2C%20updated%20%20%20%20DESC).
 
 Contributions are welcome!
+
+### Known Issues when using Podman Compose
+
+#### RHDH before 1.4.0
+
+Works with `podman-compose` only with images that include this following fix https://github.com/redhat-developer/rhdh/pull/1585
+
+Older images don't work in combination with `podman-compose`.
+This is due to https://issues.redhat.com/browse/RHIDP-3939. RHDH images currently populate dynamic-plugins-root directory with all plugins that are packaged inside the image.
+Before podman mounts volume over `dynamic-plugins-root` directory it copies all existing files into the volume. When the plugins are installed using `install-dynamic-plugins.sh` script it create duplicate installations of some plugins, this situation than prevents Backstage to start.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This image supports both `amd64` and `arm64`.
       > cp configs/dynamic-plugins/dynamic-plugins.override.example.yaml configs/dynamic-plugins/dynamic-plugins.override.yaml
       > ```
 
-   - Add your plugin config overrides to:  
+   - Add your plugin config overrides to:
      `configs/dynamic-plugins/dynamic-plugins.override.yaml`
      > The override file must start with:
      > ```yaml
@@ -201,11 +201,15 @@ podman system prune --volumes # For rhdh-local running on podman
 
 ### Known Issues when using Podman Compose
 
+#### RHDH before 1.4.0
+
 Works with `podman-compose` only with images that include this following fix https://github.com/redhat-developer/rhdh/pull/1585
 
 Older images don't work in combination with `podman-compose`.
 This is due to https://issues.redhat.com/browse/RHIDP-3939. RHDH images currently populate dynamic-plugins-root directory with all plugins that are packaged inside the image.
 Before podman mounts volume over `dynamic-plugins-root` directory it copies all existing files into the volume. When the plugins are installed using `install-dynamic-plugins.sh` script it create duplicate installations of some plugins, this situation than prevents Backstage to start.
+
+#### Podman compose provider compatibility
 
 This also doesn't work with `podman compose` when using `docker-compose` as external compose provider on macOS.
 

--- a/compose-debug.yaml
+++ b/compose-debug.yaml
@@ -1,7 +1,0 @@
-services:
-  rhdh:
-    ports: # dclint disable-line no-unbound-port-interfaces
-      - "7007:7007"
-      - "127.0.0.1:9229:9229"
-    environment:
-      NODE_OPTIONS: "--inspect=0.0.0.0:9229"

--- a/compose-dynamic-plugins-root.yaml
+++ b/compose-dynamic-plugins-root.yaml
@@ -12,13 +12,9 @@
 services:
   rhdh:
     volumes:
-      - type: bind
-        source: ./dynamic-plugins-root
-        target: /opt/app-root/src/dynamic-plugins-root
+      - ./dynamic-plugins-root:/opt/app-root/src/dynamic-plugins-root
 
 
   install-dynamic-plugins:
     volumes:
-      - type: bind
-        source: ./dynamic-plugins-root
-        target: /dynamic-plugins-root
+      - ./dynamic-plugins-root:/dynamic-plugins-root

--- a/compose-dynamic-plugins-root.yaml
+++ b/compose-dynamic-plugins-root.yaml
@@ -1,0 +1,24 @@
+# This Compose file is not usable on its own.
+# It needs to be used alongside the default compose.yaml file,
+# since it overrides the containers defined in the latter.
+#
+# You can run `[podman|docker] compose -f compose.yaml -f compose-dynamic-plugins-root.yaml config`
+# to view the effective merged config.
+
+# WARNING: this file currently only works with Docker Compose. 
+# Issue with Podman Compose: https://github.com/containers/podman-compose/issues/1204
+
+
+services:
+  rhdh:
+    volumes:
+      - type: bind
+        source: ./dynamic-plugins-root
+        target: /opt/app-root/src/dynamic-plugins-root
+
+
+  install-dynamic-plugins:
+    volumes:
+      - type: bind
+        source: ./dynamic-plugins-root
+        target: /dynamic-plugins-root

--- a/compose-dynamic-plugins-root.yaml
+++ b/compose-dynamic-plugins-root.yaml
@@ -5,10 +5,6 @@
 # You can run `[podman|docker] compose -f compose.yaml -f compose-dynamic-plugins-root.yaml config`
 # to view the effective merged config.
 
-# WARNING: this file currently only works with Docker Compose. 
-# Issue with Podman Compose: https://github.com/containers/podman-compose/issues/1204
-
-
 services:
   rhdh:
     volumes:

--- a/compose.yaml
+++ b/compose.yaml
@@ -34,6 +34,9 @@ services:
       - "/opt/app-root/src/wait-for-plugins.sh"
     ports: # dclint disable-line no-unbound-port-interfaces
       - "7007:7007"
+      - "127.0.0.1:9229:9229"
+    environment:
+      NODE_OPTIONS: "--inspect=0.0.0.0:9229"
     volumes:
       - ./wait-for-plugins.sh:/opt/app-root/src/wait-for-plugins.sh:Z
       - ./configs:/opt/app-root/src/configs:Z

--- a/compose.yaml
+++ b/compose.yaml
@@ -35,22 +35,9 @@ services:
     ports: # dclint disable-line no-unbound-port-interfaces
       - "7007:7007"
     volumes:
+      - ./wait-for-plugins.sh:/opt/app-root/src/wait-for-plugins.sh:Z
       - ./configs:/opt/app-root/src/configs:Z
-      - type: bind
-        source: "./wait-for-plugins.sh"
-        target: "/opt/app-root/src/wait-for-plugins.sh"
-        bind:
-          selinux: "Z"
-      - type: bind
-        source: "./configs"
-        target: "/opt/app-root/src/configs"
-        bind:
-          selinux: "Z"
-      - type: volume
-        source: dynamic-plugins-root
-        target: /opt/app-root/src/dynamic-plugins-root
-        volume:
-          nocopy: true
+      - dynamic-plugins-root:/opt/app-root/src/dynamic-plugins-root
     depends_on:
       install-dynamic-plugins:
         condition: service_completed_successfully
@@ -71,26 +58,10 @@ services:
       - path: "./.env"
         required: false
     volumes:
-      - type: bind
-        source: "./fixes.sh"
-        target: "/opt/app-root/src/fixes.sh"
-        bind:
-          selinux: "Z"
-      - type: bind
-        source : "./local-plugins"
-        target: "/opt/app-root/src/local-plugins"
-        bind:
-          selinux: "Z"
-      - type: bind
-        source: "./configs"
-        target: "/opt/app-root/src/configs"
-        bind:
-          selinux: "Z"
-      - type: volume
-        source: dynamic-plugins-root
-        target: /dynamic-plugins-root
-        volume:
-          nocopy: true
+      - ./fixes.sh:/opt/app-root/src/fixes.sh:Z
+      - ./local-plugins:/opt/app-root/src/local-plugins:Z
+      - ./configs:/opt/app-root/src/configs:Z
+      - dynamic-plugins-root:/dynamic-plugins-root
 
 volumes:
   dynamic-plugins-root:


### PR DESCRIPTION
<!--
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description

Builds on @kadel PR in https://github.com/redhat-developer/rhdh-local/pull/44

This PR enhances RHDH Local for frontend plugin development:

- Added `compose-dynamic-plugins-root.yaml` override file for plugin development workflow
- Integrated debug configuration into main `compose.yaml` and removed standalone `compose-debug.yaml`
- Updated volume syntax to fix Podman compatibility issues
- Improved Frontend Plugin Development documentation with clearer step ordering
- Added `dynamic-plugins-root` to `.gitignore`

## Which issue(s) does this PR fix or relate to

- Improves frontend plugin development workflow
- Addresses Podman compatibility issues

## PR acceptance criteria

- [x] Documentation - Updated README.md Frontend Plugin Development section

## How to test changes / Special notes to the reviewer

Test the updated Frontend Plugin Development workflow in README.md and verify `compose-dynamic-plugins-root.yaml` works correctly for plugin
development. Confirm Podman compatibility with the volume syntax changes.
