### PR TITLE
chore: Add OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+ - rm3l
+ - benwilcock
+ - kadel
+
+reviewers:
+ - rm3l
+ - Fortune-Ndlovu
+ - gazarenkov
+ - subhashkhileri
+ - zdrapela


### PR DESCRIPTION
## Description

This adds an OWNERS file, to align with https://github.com/redhat-developer/rhdh-operator/pull/1243 and https://github.com/redhat-developer/rhdh-chart/pull/168. It adds the relevant list of people, including the current Install group members as reviewers.

## Which issue(s) does this PR fix or relate to

&mdash;

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
