### PR TITLE
chore: Adding minimum version requirements for Docker and Podman to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ To use RHDH Local you'll need a few things:
 1. An installation of Docker or Podman (with adequate resources available)
    
    - [**Docker Engine**](https://docs.docker.com/engine/) needs to be at least v28.1.0 or newer, and the [Docker Compose](https://docs.docker.com/compose/) plugin should be at least v2.24.0 or newer. This is necessary for compatibility with features such as ```env_file``` with the ```required``` key used in our compose.yaml.
-   - If using [**Podman**](https://podman.io/docs/installation), v5.4.1 or newer is recommended. And, if using [**podman-compose**](https://github.com/containers/podman-compose) as a Compose provider, we ```podman-compose``` v1.3.0.
+   - If using [**Podman**](https://podman.io/docs/installation), v5.4.1 or newer is recommended. And, if using [**podman-compose**](https://github.com/containers/podman-compose) as a Compose provider, we recommend ```podman-compose``` v1.3.0.
   
 2. An internet connection (for downloading container images, plugins, etc.)
 3. (Optional) The `git` command line client for cloning this repository (or you can download and extract the Zip from GitHub)
 4. (Optional) A GitHub account (if you want to integrate GitHub features into RHDH)
-5. (Optional) The node `npx` tool (if you intend to build dynamic plugins in RHDH). [Node.js](https://nodejs.org/en/download) v22.16.0 or newer is recommended to build, test, and run dynamic plugins effectively. This version of Node will also install the most up to date version of [npx](https://docs.npmjs.com/cli/v11/commands/npx), which has been packaged with [npm](https://docs.npmjs.com/cli/v11/commands/npm) since v7.0.0 and newer.
+5. (Optional) The node `npx` tool (if you intend to build dynamic plugins in RHDH). [Node.js](https://nodejs.org/en/download) v22.16.0 or newer is recommended to build, test, and run dynamic plugins effectively. This version of Node will also install [npx](https://docs.npmjs.com/cli/v11/commands/npx), which has been packaged with [npm](https://docs.npmjs.com/cli/v11/commands/npm) since v7.0.0 and newer.
 6. (Optional) A [Red Hat account](https://access.redhat.com/RegistryAuthentication#getting-a-red-hat-login-2) (if you want to use a PostgreSQL database)
 
 ### Note for Mac M1 users

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To use RHDH Local you'll need a few things:
 2. An internet connection (for downloading container images, plugins, etc.)
 3. (Optional) The `git` command line client for cloning this repository (or you can download and extract the Zip from GitHub)
 4. (Optional) A GitHub account (if you want to integrate GitHub features into RHDH)
-5. (Optional) The node `npx` tool (if you intend to build dynamic plugins in RHDH). The newest verion of [Node.js](https://nodejs.org/en/download) is recommended to test and run dynamic plugins effectively. This version of Node will also install the most up to date version of [npx](https://docs.npmjs.com/cli/v11/commands/npx) which has been packaged with [npm](https://docs.npmjs.com/cli/v11/commands/npm) since v7.0.0 and newer.
+5. (Optional) The node `npx` tool (if you intend to build dynamic plugins in RHDH). The newest verion of [Node.js](https://nodejs.org/en/download), v24.2.0, is recommended to test and run dynamic plugins effectively. This version of Node will also install the most up to date version of [npx](https://docs.npmjs.com/cli/v11/commands/npx) which has been packaged with [npm](https://docs.npmjs.com/cli/v11/commands/npm) since v7.0.0 and newer.
 6. (Optional) A [Red Hat account](https://access.redhat.com/RegistryAuthentication#getting-a-red-hat-login-2) (if you want to use a PostgreSQL database)
 
 ### Note for Mac M1 users

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ RHDH Local is ideal for trying out the basic features of RHDH (like Software Cat
 
 To use RHDH Local you'll need a few things:
 
-1. A PC based on an x86 64Bit (amd64) architecture (ARM is on the way)
+1. A PC based on an x86 64-bit (amd64) or ARM64 architecture (see [Note for Mac users](#note-for-mac-m1-users) below)
 1. An installation of Docker or Podman (with adequate resources available)
 2. An internet connection (for downloading container images, plugins, etc.)
 3. (Optional) The `git` command line client for cloning this repository (or you can download and extract the Zip from GitHub)

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ To use RHDH Local you'll need a few things:
 
 1. A PC based on an x86 64Bit (amd64) architecture (ARM is on the way)
 1. An installation of Docker or Podman (with adequate resources available)
-   - Docker Compose v2.24.0 +
-   - Podman Compose v1.3.0 +
 2. An internet connection (for downloading container images, plugins, etc.)
 3. (Optional) The `git` command line client for cloning this repository (or you can download and extract the Zip from GitHub)
 4. (Optional) A GitHub account (if you want to integrate GitHub features into RHDH)
@@ -74,16 +72,29 @@ This image supports both `amd64` and `arm64`.
    The recommended way is to use GitHub Apps. You can find hints on how to configure it in [github-app-credentials.example.yaml](configs/github-app-credentials.example.yaml) or a more detailed instruction in [Backstage documentation](https://backstage.io/docs/integrations/github/github-apps).
 
 2. Start RHDH Local.
-   This repository should work with either `docker compose` using Docker Engine or `podman-compose` using Podman. When using Podman there are some exceptions. Check [Known Issues when using Podman Compose](#known-issues-when-using-podman-compose) for more info.
+   This repository should work with either Docker Engine or Podman. When using Podman there are some exceptions. Check [Known Issues when using Podman Compose](#known-issues-when-using-podman-compose) for more info.
 
-   ```sh
-   podman-compose up -d
-   ```
+   **Docker**
 
-   If you prefer `docker compose` you can just replace `podman-compose` with `docker compose`
+   [Docker Engine](https://docs.docker.com/engine/) needs to be at least v28.1.0 or newer, and the [Docker Compose](https://docs.docker.com/compose/) plugin should be at least v2.24.0 or newer. This is necessary for compatibility with features such as ```env_file``` with the ```required``` key used in our compose.yaml.
 
    ```sh
    docker compose up -d
+   ```
+
+   **Podman**
+
+   If using [Podman](https://podman.io/docs/installation), v5.4.1 or newer is recommended. This uses the ```podman compose``` subcommand. [Podman Compose](https://docs.podman.io/en/v5.3.1/markdown/podman-compose.1.html) is part of the Podman CLI and supports most Compose features required by rhdh-local.
+
+   ```sh
+   podman compose up -d
+   ```
+   **podman-compose**
+   
+   [podman-compose](https://github.com/containers/podman-compose) is a separate Python tool and standalone Compose provider that uses Podman. ```podman-compose``` requires v1.3.0 or newer, however, using ```podman compose``` with a recent version of Podman is recommended for best results.
+
+   ```sh
+   podman-compose up -d
    ```
 
 3. Open [http://localhost:7007](http://localhost:7007) in your browser to access RHDH.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To use RHDH Local you'll need a few things:
 2. An internet connection (for downloading container images, plugins, etc.)
 3. (Optional) The `git` command line client for cloning this repository (or you can download and extract the Zip from GitHub)
 4. (Optional) A GitHub account (if you want to integrate GitHub features into RHDH)
-5. (Optional) The node `npx` tool (if you intend to use GitHub authentication in RHDH)
+5. (Optional) The node `npx` tool (if you intend to build dynamic plugins in RHDH). The newest verion of [Node.js](https://nodejs.org/en/download) is recommended to test and run dynamic plugins effectively. This version of Node will also install the most up to date version of [npx](https://docs.npmjs.com/cli/v11/commands/npx) which has been packaged with [npm](https://docs.npmjs.com/cli/v11/commands/npm) since v7.0.0 and newer.
 6. (Optional) A [Red Hat account](https://access.redhat.com/RegistryAuthentication#getting-a-red-hat-login-2) (if you want to use a PostgreSQL database)
 
 ### Note for Mac M1 users

--- a/README.md
+++ b/README.md
@@ -12,10 +12,14 @@ To use RHDH Local you'll need a few things:
 
 1. A PC based on an x86 64-bit (amd64) or ARM64 architecture (see [Note for Mac users](#note-for-mac-m1-users) below)
 1. An installation of Docker or Podman (with adequate resources available)
+   
+   - [**Docker Engine**](https://docs.docker.com/engine/) needs to be at least v28.1.0 or newer, and the [Docker Compose](https://docs.docker.com/compose/) plugin should be at least v2.24.0 or newer. This is necessary for compatibility with features such as ```env_file``` with the ```required``` key used in our compose.yaml.
+   - If using [**Podman**](https://podman.io/docs/installation), v5.4.1 or newer is recommended. And, if using [**podman-compose**](https://github.com/containers/podman-compose) as a Compose provider, we ```podman-compose``` v1.3.0.
+  
 2. An internet connection (for downloading container images, plugins, etc.)
 3. (Optional) The `git` command line client for cloning this repository (or you can download and extract the Zip from GitHub)
 4. (Optional) A GitHub account (if you want to integrate GitHub features into RHDH)
-5. (Optional) The node `npx` tool (if you intend to build dynamic plugins in RHDH). The newest version of [Node.js](https://nodejs.org/en/download), v24.2.0, is recommended to test and run dynamic plugins effectively. This version of Node will also install the most up to date version of [npx](https://docs.npmjs.com/cli/v11/commands/npx) which has been packaged with [npm](https://docs.npmjs.com/cli/v11/commands/npm) since v7.0.0 and newer.
+5. (Optional) The node `npx` tool (if you intend to build dynamic plugins in RHDH). [Node.js](https://nodejs.org/en/download) v22.16.0 or newer is recommended to build, test, and run dynamic plugins effectively. This version of Node will also install the most up to date version of [npx](https://docs.npmjs.com/cli/v11/commands/npx), which has been packaged with [npm](https://docs.npmjs.com/cli/v11/commands/npm) since v7.0.0 and newer.
 6. (Optional) A [Red Hat account](https://access.redhat.com/RegistryAuthentication#getting-a-red-hat-login-2) (if you want to use a PostgreSQL database)
 
 ### Note for Mac M1 users
@@ -76,22 +80,16 @@ This image supports both `amd64` and `arm64`.
 
    **Docker**
 
-   [Docker Engine](https://docs.docker.com/engine/) needs to be at least v28.1.0 or newer, and the [Docker Compose](https://docs.docker.com/compose/) plugin should be at least v2.24.0 or newer. This is necessary for compatibility with features such as ```env_file``` with the ```required``` key used in our compose.yaml.
-
    ```sh
    docker compose up -d
    ```
 
    **Podman**
 
-   If using [Podman](https://podman.io/docs/installation), v5.4.1 or newer is recommended. This uses the ```podman compose``` subcommand. [Podman Compose](https://docs.podman.io/en/v5.3.1/markdown/podman-compose.1.html) is part of the Podman CLI and supports most Compose features required by rhdh-local.
-
    ```sh
    podman compose up -d
    ```
    **podman-compose**
-   
-   [podman-compose](https://github.com/containers/podman-compose) is a separate Python tool and standalone Compose provider that uses Podman. ```podman-compose``` requires v1.3.0 or newer, however, using ```podman compose``` with a recent version of Podman is recommended for best results.
 
    ```sh
    podman-compose up -d

--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ To use RHDH Local you'll need a few things:
 
 1. A PC based on an x86 64Bit (amd64) architecture (ARM is on the way)
 1. An installation of Docker or Podman (with adequate resources available)
-1. An internet connection (for downloading container images, plugins, etc.)
-1. (Optional) The `git` command line client for cloning this repository (or you can download and extract the Zip from GitHub)
-1. (Optional) A GitHub account (if you want to integrate GitHub features into RHDH)
-1. (Optional) The node `npx` tool (if you intend to use GitHub authentication in RHDH)
-1. (Optional) A [Red Hat account](https://access.redhat.com/RegistryAuthentication#getting-a-red-hat-login-2) (if you want to use a PostgreSQL database)
+   1. Docker Compose v2.24.0 +
+   2. Podman Compose v1.3.0 +
+2. An internet connection (for downloading container images, plugins, etc.)
+3. (Optional) The `git` command line client for cloning this repository (or you can download and extract the Zip from GitHub)
+4. (Optional) A GitHub account (if you want to integrate GitHub features into RHDH)
+5. (Optional) The node `npx` tool (if you intend to use GitHub authentication in RHDH)
+6. (Optional) A [Red Hat account](https://access.redhat.com/RegistryAuthentication#getting-a-red-hat-login-2) (if you want to use a PostgreSQL database)
 
 ### Note for Mac M1 users
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To use RHDH Local you'll need a few things:
 2. An internet connection (for downloading container images, plugins, etc.)
 3. (Optional) The `git` command line client for cloning this repository (or you can download and extract the Zip from GitHub)
 4. (Optional) A GitHub account (if you want to integrate GitHub features into RHDH)
-5. (Optional) The node `npx` tool (if you intend to build dynamic plugins in RHDH). The newest verion of [Node.js](https://nodejs.org/en/download), v24.2.0, is recommended to test and run dynamic plugins effectively. This version of Node will also install the most up to date version of [npx](https://docs.npmjs.com/cli/v11/commands/npx) which has been packaged with [npm](https://docs.npmjs.com/cli/v11/commands/npm) since v7.0.0 and newer.
+5. (Optional) The node `npx` tool (if you intend to build dynamic plugins in RHDH). The newest version of [Node.js](https://nodejs.org/en/download), v24.2.0, is recommended to test and run dynamic plugins effectively. This version of Node will also install the most up to date version of [npx](https://docs.npmjs.com/cli/v11/commands/npx) which has been packaged with [npm](https://docs.npmjs.com/cli/v11/commands/npm) since v7.0.0 and newer.
 6. (Optional) A [Red Hat account](https://access.redhat.com/RegistryAuthentication#getting-a-red-hat-login-2) (if you want to use a PostgreSQL database)
 
 ### Note for Mac M1 users

--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@ RHDH Local is ideal for trying out the basic features of RHDH (like Software Cat
 
 To use RHDH Local you'll need a few things:
 
-1. A PC based on an x86 64-bit (amd64) or ARM64 architecture (see [Note for Mac users](#note-for-mac-m1-users) below)
-1. An installation of Docker or Podman (with adequate resources available)
+1. A PC based on an x86 64-bit (amd64) architecture (ARM is on the way, but see [Note for Mac M-series users](#note-for-mac-m1-users) below)
+2. An installation of Docker or Podman (with adequate resources available)
    
    - [**Docker Engine**](https://docs.docker.com/engine/) needs to be at least v28.1.0 or newer, and the [Docker Compose](https://docs.docker.com/compose/) plugin should be at least v2.24.0 or newer. This is necessary for compatibility with features such as ```env_file``` with the ```required``` key used in our compose.yaml.
    - If using [**Podman**](https://podman.io/docs/installation), v5.4.1 or newer is recommended. And, if using [**podman-compose**](https://github.com/containers/podman-compose) as a Compose provider, we recommend ```podman-compose``` v1.3.0.
   
-2. An internet connection (for downloading container images, plugins, etc.)
-3. (Optional) The `git` command line client for cloning this repository (or you can download and extract the Zip from GitHub)
-4. (Optional) A GitHub account (if you want to integrate GitHub features into RHDH)
-5. (Optional) The node `npx` tool (if you intend to build dynamic plugins in RHDH). [Node.js](https://nodejs.org/en/download) v22.16.0 or newer is recommended to build, test, and run dynamic plugins effectively. This version of Node will also install [npx](https://docs.npmjs.com/cli/v11/commands/npx), which has been packaged with [npm](https://docs.npmjs.com/cli/v11/commands/npm) since v7.0.0 and newer.
-6. (Optional) A [Red Hat account](https://access.redhat.com/RegistryAuthentication#getting-a-red-hat-login-2) (if you want to use a PostgreSQL database)
+3. An internet connection (for downloading container images, plugins, etc.)
+4. (Optional) The `git` command line client for cloning this repository (or you can download and extract the Zip from GitHub)
+5. (Optional) A GitHub account (if you want to integrate GitHub features into RHDH)
+6. (Optional) The node `npx` tool (if you intend to build dynamic plugins in RHDH). [Node.js](https://nodejs.org/en/download) v22.16.0 or newer is recommended to build, test, and run dynamic plugins effectively. This version of Node will also install [npx](https://docs.npmjs.com/cli/v11/commands/npx), which has been packaged with [npm](https://docs.npmjs.com/cli/v11/commands/npm) since v7.0.0 and newer.
+7. (Optional) A [Red Hat account](https://access.redhat.com/RegistryAuthentication#getting-a-red-hat-login-2) (if you want to use a PostgreSQL database)
 
 ### Note for Mac M1 users
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ To use RHDH Local you'll need a few things:
 
 1. A PC based on an x86 64Bit (amd64) architecture (ARM is on the way)
 1. An installation of Docker or Podman (with adequate resources available)
-   1. Docker Compose v2.24.0 +
-   2. Podman Compose v1.3.0 +
+   - Docker Compose v2.24.0 +
+   - Podman Compose v1.3.0 +
 2. An internet connection (for downloading container images, plugins, etc.)
 3. (Optional) The `git` command line client for cloning this repository (or you can download and extract the Zip from GitHub)
 4. (Optional) A GitHub account (if you want to integrate GitHub features into RHDH)


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
Updating README to include minimum versions of compose tools (Docker and Podman). Added the minimum versions under the What You'll Need Before You Get Started.

## Which issue(s) does this PR fix or relate to

- Fixes [RHIDP-7585](https://issues.redhat.com/browse/RHIDP-7585)

## PR acceptance criteria

- [x] Tests
- [x] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Summary by Sourcery

Update README to specify minimum version requirements for Docker, Docker Compose, Podman, podman-compose, and Node.js, add ARM64 architecture support, and reorganize prerequisite and startup instructions.

Documentation:
- Include minimum version requirements for Docker Engine (>=28.1.0), Docker Compose plugin (>=2.24.0), Podman CLI (>=5.4.1), podman-compose (>=1.3.0), and Node.js (>=24.2.0) in the prerequisites section
- Expand supported architectures to include ARM64 and reorganize the list of prerequisites
- Split the startup section into separate Docker, Podman, and podman-compose instructions with associated version notes