### PR TITLE
test

### DIFF
--- a/prepare-and-install-dynamic-plugins.sh
+++ b/prepare-and-install-dynamic-plugins.sh
@@ -1,53 +1,82 @@
 #!/bin/sh
 
-# Workaround for various issues
+set -euo pipefail
 
-# Fix for https://issues.redhat.com/browse/RHIDP-3939
-# needed for < 1.4
-# if there is no config than the files in dynamic-plugins-root are from the image, and we need to remove them
+# Terminal colors
+NC='\033[0m'
+BOLD='\033[1m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+CYAN='\033[0;36m'
 
-# Entrypoint for the install-dynamic-plugins container.
-# Prepares the dynamic-plugins config, applies compatibility fixes,
-# and runs install-dynamic-plugins.sh to generate app-config.dynamic-plugins.yaml.
+log_info()    { echo "${GREEN}[INFO]${NC} $1"; }
+log_warn()    { echo "${YELLOW}[WARN]${NC} $1"; }
+log_error()   { echo "${RED}[ERROR]${NC} $1"; }
+log_step()    { echo "${BOLD}${CYAN}==> $1${NC}"; }
 
+log_step "Checking RHIDP-3939 workaround prerequisites"
+
+# Fix for RHIDP-3939
 if [ -d "dynamic-plugins-root" ]; then
-    echo "dynamic-plugins-root exists"
+    log_info "'dynamic-plugins-root' directory exists"
     if [ ! -f "dynamic-plugins-root/app-config.dynamic-plugins.yaml" ]; then
-        echo "app-config.dynamic-plugins.yaml does not exist"
-        echo "Removing dynamic-plugins-root to fix RHIDP-3939"
+        log_warn "'app-config.dynamic-plugins.yaml' is missing"
+        log_info "Removing 'dynamic-plugins-root' to fix RHIDP-3939"
         rm -rf ./dynamic-plugins-root
+    else
+        log_info "'app-config.dynamic-plugins.yaml' exists — no action needed"
     fi
+else
+    log_info "'dynamic-plugins-root' does not exist — nothing to do"
 fi
 
-# Fix for https://issues.redhat.com/browse/RHIDP-4410
-# needed for < 1.3.0
-echo "Removing ~/.npmrc to fix RHIDP-4410"
-rm -rf ~/.npmrc
+log_step "Applying RHIDP-4410 workaround"
 
-# handle dynamic-plugins config override
+# Fix for RHIDP-4410
+if [ -f "$HOME/.npmrc" ]; then
+    log_info "Removing user .npmrc to avoid build issues (RHIDP-4410)"
+    rm -f "$HOME/.npmrc"
+else
+    log_info "No user .npmrc found — skipping"
+fi
+
+log_step "Configuring dynamic-plugins.yaml symlink"
+
+# Handle dynamic plugins override
 DYNAMIC_PLUGINS_DEFAULT="/opt/app-root/src/configs/dynamic-plugins/dynamic-plugins.yaml"
 DYNAMIC_PLUGINS_OVERRIDE="/opt/app-root/src/configs/dynamic-plugins/dynamic-plugins.override.yaml"
 LINK_TARGET="/opt/app-root/src/dynamic-plugins.yaml"
-NPMRC_PATH="/opt/app-root/src/configs/.npmrc"
 
 if [ -f "$DYNAMIC_PLUGINS_OVERRIDE" ]; then
-    echo "Using dynamic-plugins.override.yaml"
+    log_info "Using override: dynamic-plugins.override.yaml"
     ln -sf "$DYNAMIC_PLUGINS_OVERRIDE" "$LINK_TARGET"
 elif [ -f "/opt/app-root/src/configs/dynamic-plugins.yaml" ]; then
-    echo "[warn] Using legacy dynamic-plugins.yaml. This method is deprecated. You can override the dynamic plugins configuration by renaming your file into configs/dynamic-plugins/dynamic-plugins.override.yaml"
+    log_warn "Using legacy dynamic-plugins.yaml (deprecated)"
+    log_warn "Rename it to dynamic-plugins.override.yaml for clarity"
     ln -sf "/opt/app-root/src/configs/dynamic-plugins.yaml" "$LINK_TARGET"
 else
-    echo "Using default dynamic-plugins.yaml"
+    log_info "Falling back to default dynamic-plugins.yaml"
     ln -sf "$DYNAMIC_PLUGINS_DEFAULT" "$LINK_TARGET"
 fi
 
-# If a .npmrc was mounted, set the NPM_CONFIG_USERCONFIG env var
+log_step "Checking for mounted .npmrc"
+
+# Handle mounted .npmrc
+NPMRC_PATH="/opt/app-root/src/configs/.npmrc"
 if [ -f "$NPMRC_PATH" ]; then
-    echo "Found .npmrc, setting NPM_CONFIG_USERCONFIG"
+    log_info "Found mounted .npmrc — exporting NPM_CONFIG_USERCONFIG"
     export NPM_CONFIG_USERCONFIG="$NPMRC_PATH"
 else
-    echo "No .npmrc found, skipping NPM_CONFIG_USERCONFIG"
+    log_info "No .npmrc found — skipping NPM_CONFIG_USERCONFIG"
 fi
 
-echo "Running install-dynamic-plugins.sh"
-./install-dynamic-plugins.sh /dynamic-plugins-root
+log_step "Running plugin installer script"
+
+if [ -x ./install-dynamic-plugins.sh ]; then
+    ./install-dynamic-plugins.sh /dynamic-plugins-root
+    log_info "Dynamic plugins installed successfully"
+else
+    log_error "'install-dynamic-plugins.sh' not found or not executable"
+    exit 1
+fi


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
<!--
Please explain the changes you made here.
-->

## Which issue(s) does this PR fix or relate to

- Fixes #_issue_number_

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Summary by Sourcery

Enhance the dynamic plugins preparation script with robust error handling, informative logging, and conditional workarounds for RHIDP-3939 and RHIDP-4410, while improving configuration symlink logic and installer validation.

Bug Fixes:
- Conditionally remove stale `dynamic-plugins-root` to fix RHIDP-3939 only when needed
- Remove user `~/.npmrc` for RHIDP-4410 only if it exists

Enhancements:
- Enable strict mode (`set -euo pipefail`) for safer script execution
- Add colored logging functions and structured log steps for better visibility
- Unify dynamic-plugins.yaml symlink logic with override, legacy, and default handling
- Detect and export mounted `.npmrc` via `NPM_CONFIG_USERCONFIG` when present
- Check that `install-dynamic-plugins.sh` is executable before running and log success or error