### PR TITLE
chore: update default.env to point to the same value as in the compose.yaml (RHIDP-7829)

### DIFF
--- a/default.env
+++ b/default.env
@@ -7,10 +7,9 @@ POSTGRES_PASSWORD=postgres
 
 BASE_URL=http://localhost:7007
 
-# configure images to use
-# RHDH_IMAGE=quay.io/rhdh/rhdh-hub-rhel9:1.4
-# This is an nightly build. This image is available for both amd64 and arm64
-#RHDH_IMAGE=quay.io/rhdh-community/rhdh:next
+# configure image to use: default to using the latest stable tag of the community builds, which are build for both amd64 and arm64 architectures
+# to use bleeding edge :next images or commercially supported images, see README.md for details
+# RHDH_IMAGE=quay.io/rhdh-community/rhdh:1.6
 
 # GitHub auth (you need to uncomment github auth section in configs/app-config.local.yaml to enable this)
 #AUTH_GITHUB_CLIENT_ID=
@@ -36,4 +35,3 @@ SEGMENT_WRITE_KEY=gGVM6sYRK0D0ndVX22BOtS7NRcxPej8t
 # NO_PROXY will take effect only if HTTP(S)_PROXY env vars are set.
 # See the compose-with-corporate-proxy.yaml file.
 #NO_PROXY=localhost,127.0.0.1
-


### PR DESCRIPTION
### What does this PR do?

chore: update default.env to point to the same value as in the compose.yaml (RHIDP-7829)

Signed-off-by: rhdh-bot service account <rhdh-bot@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

## Summary by Sourcery

Chores:
- Align default.env value with compose.yaml for consistency