### PR TITLE
add --no-node-snapshot for scaffolder plugin to work

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -36,7 +36,7 @@ services:
       - "7007:7007"
       - "127.0.0.1:9229:9229"
     environment:
-      NODE_OPTIONS: "--inspect=0.0.0.0:9229"
+      NODE_OPTIONS: "--inspect=0.0.0.0:9229 --no-node-snapshot"
     volumes:
       - ./wait-for-plugins-and-start.sh:/opt/app-root/src/wait-for-plugins-and-start.sh:Z
       - ./configs:/opt/app-root/src/configs:Z


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
<!--
Please explain the changes you made here.
-->
When using Node.js version 20 or newer, the scaffolder backend plugin requires that it be started with the --no-node-snapshot option.    Please make sure that you have NODE_OPTIONS=--no-node-snapshot in your environment.

## Which issue(s) does this PR fix or relate to

- Fixes #_issue_number_

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Summary by Sourcery

Bug Fixes:
- Include --no-node-snapshot in NODE_OPTIONS of compose.yaml to prevent startup errors with Node.js 20 and newer