### PR TITLE
ci: Trigger test workflow on release branches as well

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,12 +2,16 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
+      - release-1.[0-9]+
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - main
+      - release-1.[0-9]+
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Description
Otherwise, the required checks would remain stuck.

This is to unblock https://github.com/redhat-developer/rhdh-local/pull/62

## Which issue(s) does this PR fix or relate to

&mdash;

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Summary by Sourcery

Update the test CI workflow to run on release branches and key concurrency group on branch ref

CI:
- Add release-1.x branch pattern to push and pull_request triggers
- Use branch ref instead of event number for workflow concurrency grouping