### PR TITLE
chore: Adding shellcheck disable to ignore error SC2086 for CLI args

### DIFF
--- a/wait-for-plugins-and-start.sh
+++ b/wait-for-plugins-and-start.sh
@@ -51,6 +51,8 @@ elif [ -f "$LEGACY_USER_APP_CONFIG" ]; then
 fi
 
 # Start Backstage backend
+# shellcheck disable=SC2086 
+# Allows variable expansion for CLI args
 exec node packages/backend --no-node-snapshot \
   --config "app-config.yaml" \
   --config app-config.example.yaml \

--- a/wait-for-plugins-and-start.sh
+++ b/wait-for-plugins-and-start.sh
@@ -51,8 +51,8 @@ elif [ -f "$LEGACY_USER_APP_CONFIG" ]; then
 fi
 
 # Start Backstage backend
-# shellcheck disable=SC2086 
 # Allows variable expansion for CLI args
+# shellcheck disable=SC2086 
 exec node packages/backend --no-node-snapshot \
   --config "app-config.yaml" \
   --config app-config.example.yaml \


### PR DESCRIPTION
## Description
Making a small change to add a shellCheck disable line so that the shellcheck ignores an error that would change how the code runs

## Which issue(s) does this PR fix or relate to

- [RHDHBUGS-790](https://issues.redhat.com/browse/RHDHBUGS-790)

## PR acceptance criteria

- [x] Tests
- [x] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Summary by Sourcery

Enhancements:
- Add a shellcheck disable comment for SC2086 in wait-for-plugins-and-start.sh to preserve CLI args