### PR TITLE
chore: readme indentation fixup

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,28 +67,28 @@ This method creates RHDH Local without any additional configurations or plugins.
      orchestrator dynamic plugins from `dynamic-plugins.yaml` to your `dynamic-plugins.override.yaml` version for your local
      development.
 
-- Add your catalog entity overrides:
+   - Add your catalog entity overrides:
 
-   Start by copying the example files provided:
+      Start by copying the example files provided:
 
-   ```sh
-      cp configs/catalog-entities/users.override.example.yaml configs/catalog-entities/users.override.yaml
-      cp configs/catalog-entities/components.override.example.yaml configs/catalog-entities/components.override.yaml
-   ```
+      ```sh
+         cp configs/catalog-entities/users.override.example.yaml configs/catalog-entities/users.override.yaml
+         cp configs/catalog-entities/components.override.example.yaml configs/catalog-entities/components.override.yaml
+      ```
 
-   Once copied, you can modify these override files to customize your catalog users or components.
-   If these `.override.yaml` files are present, RHDH Local will automatically use them instead of the default `users.yaml` or `components.yaml`.
+      Once copied, you can modify these override files to customize your catalog users or components.
+      If these `.override.yaml` files are present, RHDH Local will automatically use them instead of the default `users.yaml` or `components.yaml`.
 
-   No additional configuration is required — just drop the file in place and restart RHDH.
+      No additional configuration is required — just drop the file in place and restart RHDH.
 
-   You can add any extra files (like GitHub credentials) to: `configs/extra-files/`
+      You can add any extra files (like GitHub credentials) to: `configs/extra-files/`
 
-   If present, these files will be automatically loaded by the system on startup.
+      If present, these files will be automatically loaded by the system on startup.
 
-   If you need features that fetch files from GitHub you should configure `integrations.github`.
-   The recommended way is to use GitHub Apps. You can find hints on how to configure it in [github-app-credentials.example.yaml](configs/github-app-credentials.example.yaml) or a more detailed instruction in [Backstage documentation](https://backstage.io/docs/integrations/github/github-apps).
+      If you need features that fetch files from GitHub you should configure `integrations.github`.
+      The recommended way is to use GitHub Apps. You can find hints on how to configure it in [github-app-credentials.example.yaml](configs/github-app-credentials.example.yaml) or a more detailed instruction in [Backstage documentation](https://backstage.io/docs/integrations/github/github-apps).
 
-1. Start RHDH Local.
+4. Start RHDH Local.
    This repository works with both Podman and Docker.
 
    **Podman**
@@ -103,7 +103,7 @@ This method creates RHDH Local without any additional configurations or plugins.
    docker compose up -d
    ```
 
-2. Open [http://localhost:7007](http://localhost:7007) in your browser to access RHDH. If you have not set up and enabled GitHub authentication, you will need to login as 'GUEST'.
+5. Open [http://localhost:7007](http://localhost:7007) in your browser to access RHDH. If you have not set up and enabled GitHub authentication, you will need to login as 'GUEST'.
    
    ![RHDH-Local Homepage](additional-config-guides/images/RHDH-Homepage.png)
 

--- a/README.md
+++ b/README.md
@@ -69,18 +69,17 @@ This method creates RHDH Local without any additional configurations or plugins.
 
 - Add your catalog entity overrides:
 
-      > Start by copying the example files provided:
-      >
-      > ```sh
-      > cp configs/catalog-entities/users.override.example.yaml configs/catalog-entities/users.override.yaml
-      > cp configs/catalog-entities/components.override.example.yaml configs/catalog-entities/components.override.yaml
-      > ```
+   Start by copying the example files provided:
 
-      Once copied, you can modify these override files to customize your catalog users or components.
-      If these `.override.yaml` files are present, RHDH Local will automatically use them instead of the default `users.yaml` or `components.yaml`.
+   ```sh
+      cp configs/catalog-entities/users.override.example.yaml configs/catalog-entities/users.override.yaml
+      cp configs/catalog-entities/components.override.example.yaml configs/catalog-entities/components.override.yaml
+   ```
 
-      No additional configuration is required — just drop the file in place and restart RHDH.
+   Once copied, you can modify these override files to customize your catalog users or components.
+   If these `.override.yaml` files are present, RHDH Local will automatically use them instead of the default `users.yaml` or `components.yaml`.
 
+   No additional configuration is required — just drop the file in place and restart RHDH.
 
    - Add any extra files (like GitHub credentials) to: `configs/extra-files/`
 

--- a/README.md
+++ b/README.md
@@ -81,14 +81,14 @@ This method creates RHDH Local without any additional configurations or plugins.
 
    No additional configuration is required — just drop the file in place and restart RHDH.
 
-   - Add any extra files (like GitHub credentials) to: `configs/extra-files/`
+   You can add any extra files (like GitHub credentials) to: `configs/extra-files/`
 
    If present, these files will be automatically loaded by the system on startup.
 
    If you need features that fetch files from GitHub you should configure `integrations.github`.
    The recommended way is to use GitHub Apps. You can find hints on how to configure it in [github-app-credentials.example.yaml](configs/github-app-credentials.example.yaml) or a more detailed instruction in [Backstage documentation](https://backstage.io/docs/integrations/github/github-apps).
 
-4. Start RHDH Local.
+1. Start RHDH Local.
    This repository works with both Podman and Docker.
 
    **Podman**
@@ -103,7 +103,7 @@ This method creates RHDH Local without any additional configurations or plugins.
    docker compose up -d
    ```
 
-5. Open [http://localhost:7007](http://localhost:7007) in your browser to access RHDH. If you have not set up and enabled GitHub authentication, you will need to login as 'GUEST'.
+2. Open [http://localhost:7007](http://localhost:7007) in your browser to access RHDH. If you have not set up and enabled GitHub authentication, you will need to login as 'GUEST'.
    
    ![RHDH-Local Homepage](additional-config-guides/images/RHDH-Homepage.png)
 


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
chore: readme indentation fixup
From:
<img width="879" height="374" alt="image" src="https://github.com/user-attachments/assets/00a38496-6f0c-4bb1-a2b8-adbfaa28762f" />
To:
<img width="822" height="266" alt="image" src="https://github.com/user-attachments/assets/eed92c86-6733-4824-9e50-a02e5a7ff052" />

## Which issue(s) does this PR fix or relate to

- Fixes #_issue_number_

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Summary by Sourcery

Fix indentation and formatting in README.md for improved list and code block consistency

Documentation:
- Standardize list indentation in the catalog entity overrides and extra files sections
- Re-indent shell code blocks and GitHub integration instructions for consistent formatting