### PR TITLE
chore(doc): add community/rhdh:next-1.7 tags to container-image-guide.md

### DIFF
--- a/additional-config-guides/container-image-guide.md
+++ b/additional-config-guides/container-image-guide.md
@@ -28,6 +28,12 @@ Looking for the bleeding edge? To use the most recent nightly community build of
 RHDH_IMAGE=quay.io/rhdh-community/rhdh:next
 ```
 
+Or, for builds from a given `release-1.y` branch (for example, 1.7), set the variable as follows.
+
+```sh
+RHDH_IMAGE=quay.io/rhdh-community/rhdh:next-1.7
+```
+
 ### Using unsupported pre-release CI builds
 
 Continuous Integration (CI) builds on from [quay.io/rhdh/rhdh-hub-rhel9](https://quay.io/rhdh/rhdh-hub-rhel9), while unsupported, provide early access to commercially supported builds and bug fixes.


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description

chore(doc): add community/rhdh:next-1.7 tags to container-image-guide.md

## Which issue(s) does this PR fix or relate to

- Fixes https://issues.redhat.com/browse/RHIDP-8256

## PR acceptance criteria

- [n/a ] Tests
- [x] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

Read the change. Try it in your rhdh-local.

## Summary by Sourcery

Documentation:
- Add example of setting RHDH_IMAGE to quay.io/rhdh-community/rhdh:next-1.7 for release-1.y builds