### PR TITLE
Update Sonataflow Image for Orchestrator

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,14 +43,13 @@ jobs:
             cliArgs: "-f compose.yaml -f compose-with-corporate-proxy.yaml"
           - name: "dynamic-plugins-root"
             cliArgs: "-f compose.yaml -f compose-dynamic-plugins-root.yaml"
-          # TODO(jenniferubah): Uncomment this when https://issues.redhat.com/browse/FLPATH-2500 is resolved.
-#         - name: "orchestrator-workflow"
-#           cliArgs: "-f compose.yaml -f orchestrator/compose.yaml"
+          - name: "orchestrator-workflow"
+            cliArgs: "-f compose.yaml -f orchestrator/compose.yaml"
           - name: "developer-lightspeed-minimal"
             cliArgs: "-f compose.yaml -f developer-lightspeed/compose.yaml"
           - name: "developer-lightspeed"
             cliArgs: "-f compose.yaml -f developer-lightspeed/compose-with-ollama.yaml"
-            
+
     name: "${{ matrix.tool }} compose - ${{ matrix.composeConfig.name }}"
     runs-on: ubuntu-latest
     env:

--- a/orchestrator/compose.yaml
+++ b/orchestrator/compose.yaml
@@ -17,7 +17,7 @@ services:
 
   sonataflow:
     container_name: sonataflow
-    image: "${SONATAFLOW_IMAGE:-registry.redhat.io/openshift-serverless-1/logic-swf-devmode-rhel8:1.36.0}"
+    image: "${SONATAFLOW_IMAGE:-quay.io/kubesmarts/incubator-kie-sonataflow-devmode:main}"
     env_file:
       - path: "./default.env"
         required: true

--- a/orchestrator/docs/orchestrator-workflow-guide.md
+++ b/orchestrator/docs/orchestrator-workflow-guide.md
@@ -17,9 +17,6 @@ plugins: []
 To set up the infrastructure for developing workflow with Orchestrator, you must merge and run these two compose files:
 [`compose.yaml`](../../compose.yaml) and [`orchestrator/compose.yaml`](../compose.yaml) configs.
 
-> **NOTE**: You must log in to RedHat Registry to use the Sonataflow dev image. To get an account,
-> check [Red Hat Login](https://access.redhat.com/RegistryAuthentication#getting-a-red-hat-login-2).
-
 To get started, run the command below or override the `RHDH_ORCHESTRATOR_WORKFLOWS` variable in your `.env` file to
 point to your local workflow development directory before running the command.
 


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
Update Sonataflow image to point to upstream version. Also enabled test and documentation.

## Which issue(s) does this PR fix or relate to

- https://issues.redhat.com/browse/FLPATH-2500

## PR acceptance criteria

- [x] Tests
- [x] Documentation

## How to test changes / Special notes to the reviewer
Run `podman-compose -f compose.yaml -f orchestrator/compose.yaml up -d` and follow the orchestrator doc for more details.

## Summary by Sourcery

Update Sonataflow image reference in orchestrator compose and enable orchestrator integration tests in CI

Enhancements:
- Update default Sonataflow image to use the upstream quay.io/kubesmarts/incubator-kie-sonataflow-devmode:main version

CI:
- Uncomment orchestrator-workflow in GitHub Actions test matrix to include orchestrator compose tests