### PR TITLE
docs(orchestrator): Move the guide to a dedicated `orchestrator/README.md` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ If you would like to change your RHDH-Local setup, or add additional features or
 2. [Container Image Guide](./additional-config-guides/container-image-guide.md) - how to switch to a more bleeding edge, or commercially supported version of RHDH
 3. [Simulated Proxy Setup](./additional-config-guides/proxy-setup-sim.md) - testing in a simulated proxy environment
 4. [PostgreSQL Guide](./additional-config-guides/postgresql-guide.md) - using PostgreSQL instead of an in-memory database
-5. [Orchestrator Workflow Guide](./orchestrator/docs/orchestrator-workflow-guide.md) - using Orchestrator with RHDH to develop workflows.
+5. [Orchestrator Workflow Guide](./orchestrator/README.md) - using Orchestrator with RHDH to develop workflows.
 6. [Developer Lightspeed Guide](./developer-lightspeed/README.md) - using Developer Lightspeed in RHDH Local.
 
 ## Contributing and reporting issues

--- a/orchestrator/README.md
+++ b/orchestrator/README.md
@@ -15,7 +15,7 @@ plugins: []
 ```
 
 To set up the infrastructure for developing workflow with Orchestrator, you must merge and run these two compose files:
-[`compose.yaml`](../../compose.yaml) and [`orchestrator/compose.yaml`](../compose.yaml) configs.
+[`compose.yaml`](../compose.yaml) and [`orchestrator/compose.yaml`](./compose.yaml) configs.
 
 To get started, run the command below or override the `RHDH_ORCHESTRATOR_WORKFLOWS` variable in your `.env` file to
 point to your local workflow development directory before running the command.
@@ -43,14 +43,14 @@ podman compose \
 
 There are three workflow examples to get you started on testing Orchestrator workflow with RHDH Local.
 
-1. The [`orchestrator/workflow-examples`](../workflow-examples/) folder contains example workflows and by default, it is already
+1. The [`orchestrator/workflow-examples`](./workflow-examples/) folder contains example workflows and by default, it is already
    mounted
    to
    `/home/kogito/serverless-workflow-project/src/main/resources` for SonataFlow configuration in your
    `compose-orchestrator.local.yaml`. The
    directory contains three workflows; greeting, slack and github. For more information about the workflow and setup,
    refer to this
-   [link](../workflow-examples/README.md).
+   [link](./workflow-examples/README.md).
 
 2. A suite of workflows exists in
    this [backstage-orchestrator-workflows](https://github.com/rhdhorchestrator/backstage-orchestrator-workflows/tree/main/workflows).


### PR DESCRIPTION
## Description

Follow-up to https://github.com/redhat-developer/rhdh-local/pull/64#discussion_r2232987915

Similar to the 'developer-lightspeed' structure, this would make it easy to find and super obvious as a starting place for the user.

## Which issue(s) does this PR fix or relate to

&mdash;

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Summary by Sourcery

Move the Orchestrator workflow guide into its own top-level README and update references accordingly

Enhancements:
- Relocate the orchestrator guide from docs/orchestrator-workflow-guide.md to orchestrator/README.md
- Refresh internal compose and example links in the moved guide to use correct relative paths
- Update the main README to point to the new orchestrator README location