### PR TITLE
fix: use correct relative path for github credentials

### DIFF
--- a/configs/app-config/app-config.yaml
+++ b/configs/app-config/app-config.yaml
@@ -13,7 +13,7 @@ auth:
 #   github:
 #     - host: github.com
 #       apps:
-#         - $include: github-app-credentials.yaml
+#         - $include: ../extra-files/github-app-credentials.yaml
 
 app:
   title: Red Hat Developer Hub


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
Fixes the example app config to use the correct path for loading GitHub credentials

## Which issue(s) does this PR fix or relate to

N/A

## PR acceptance criteria

N/A

## How to test changes / Special notes to the reviewer

Enable the GitHub integration and attempt to load the `github-app-credentials.yaml` using the old vs new path. An error is logged using the old path since RHDH cannot load it.

## Summary by Sourcery

Bug Fixes:
- Correct the example app-config.yaml to use the proper relative path for the GitHub credentials file