### PR TITLE
chore: Adding quay.io plugin to default configuration

### DIFF
--- a/configs/app-config/app-config.yaml
+++ b/configs/app-config/app-config.yaml
@@ -51,6 +51,12 @@ backend:
     credentials: true
   csp:
    upgrade-insecure-requests: false
+   # CSP for Quay Images
+   img-src:
+    - "'self'"
+    - "data:"
+    - "https://quay.io"
+    - "https://*.quay.io"
 
 # comment out the following 'database' section to use the PostgreSQL database
   database:

--- a/configs/app-config/app-config.yaml
+++ b/configs/app-config/app-config.yaml
@@ -90,3 +90,23 @@ techdocs:
     type: local
     local:
       publishDirectory: /tmp/techdocs
+
+
+proxy:
+  endpoints:
+    '/quay/api':
+      target: 'https://quay.io'
+      credentials: require
+      headers:
+        X-Requested-With: 'XMLHttpRequest'
+        # Uncomment and use the Authorization header below to access a private Quay
+        # Repository using a token. Refer to the "Applications and Tokens" section
+        # at https://docs.quay.io/api/ to find the instructions to generate a token
+        # Authorization: 'Bearer <YOUR TOKEN>'
+      changeOrigin: true
+      # Change to "false" in case of using self hosted quay instance with a self-signed certificate
+      secure: true
+
+quay:
+  # The UI url for Quay, used to generate the link to Quay
+  uiUrl: 'https://quay.io'

--- a/configs/catalog-entities/components.yaml
+++ b/configs/catalog-entities/components.yaml
@@ -21,21 +21,6 @@
 #   owner: CNCF
 #   lifecycle: experimental
 
-# Quay Example Component
-apiVersion: backstage.io/v1alpha1
-kind: Component
-metadata:
-  name: image-registry
-  description: Quay Image Registry
-  annotations:
-    quay.io/repository-slug: rhdh-community/rhdh
-spec:
-  type: service
-  lifecycle: production
-  owner: user:default/user
-
----
-
 ###############################
 # SYSTEMS
 ###############################

--- a/configs/catalog-entities/components.yaml
+++ b/configs/catalog-entities/components.yaml
@@ -21,7 +21,20 @@
 #   owner: CNCF
 #   lifecycle: experimental
 
-# ---
+# Quay Example Component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: image-registry
+  description: Testing if this will allow the component to appear in the Software Catalog.
+  annotations:
+    quay.io/repository-slug: rhdh-community/rhdh
+spec:
+  type: service
+  lifecycle: production
+  owner: user:default/user
+
+---
 
 ###############################
 # SYSTEMS

--- a/configs/catalog-entities/components.yaml
+++ b/configs/catalog-entities/components.yaml
@@ -26,7 +26,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: image-registry
-  description: Testing if this will allow the component to appear in the Software Catalog.
+  description: Quay Image Registry
   annotations:
     quay.io/repository-slug: rhdh-community/rhdh
 spec:

--- a/configs/dynamic-plugins/dynamic-plugins.yaml
+++ b/configs/dynamic-plugins/dynamic-plugins.yaml
@@ -9,11 +9,15 @@ plugins:
 
   # Quay plugin
   - package: ./dynamic-plugins/dist/backstage-community-plugin-quay
-    disabled: true
+    disabled: false
     pluginConfig:
       dynamicPlugins:
         frontend:
           backstage-community.plugin-quay:
+            entityTabs:
+              - path: /image-registry
+                title: Image Registry
+                mountPoint: entity.page.image-registry
             mountPoints:
               - mountPoint: entity.page.image-registry/cards
                 importName: QuayPage

--- a/configs/dynamic-plugins/dynamic-plugins.yaml
+++ b/configs/dynamic-plugins/dynamic-plugins.yaml
@@ -3,7 +3,24 @@ includes:
   - dynamic-plugins.default.yaml
 
 plugins:
-  #Tech Radar frontend plugin
+  # Tech Radar frontend plugin
   - package: ./dynamic-plugins/dist/backstage-community-plugin-tech-radar
     disabled: false
+
+  # Quay plugin
+  - package: ./dynamic-plugins/dist/backstage-community-plugin-quay
+    disabled: true
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          backstage-community.plugin-quay:
+            mountPoints:
+              - mountPoint: entity.page.image-registry/cards
+                importName: QuayPage
+                config:
+                  layout:
+                    gridColumn: 1 / -1
+                  if:
+                    anyOf:
+                    - isQuayAvailable
  

--- a/configs/dynamic-plugins/dynamic-plugins.yaml
+++ b/configs/dynamic-plugins/dynamic-plugins.yaml
@@ -10,21 +10,4 @@ plugins:
   # Quay plugin
   - package: ./dynamic-plugins/dist/backstage-community-plugin-quay
     disabled: false
-    pluginConfig:
-      dynamicPlugins:
-        frontend:
-          backstage-community.plugin-quay:
-            entityTabs:
-              - path: /image-registry
-                title: Image Registry
-                mountPoint: entity.page.image-registry
-            mountPoints:
-              - mountPoint: entity.page.image-registry/cards
-                importName: QuayPage
-                config:
-                  layout:
-                    gridColumn: 1 / -1
-                  if:
-                    anyOf:
-                    - isQuayAvailable
  


### PR DESCRIPTION
## Description
Adding Quay.io to default configuration of RHDH local. It has to enabled by default and contain some basic integrations.

## Which issue(s) does this PR fix or relate to

[RHIDP-8508](https://issues.redhat.com/browse/RHIDP-8508)

## PR acceptance criteria

- [x] Tests
- [x] Documentation

## How to test changes / Special notes to the reviewer

## Summary by Sourcery

Add the Quay.io community plugin to the default dynamic plugins configuration

New Features:
- Include the Quay community plugin in the default dynamic-plugins.yaml

Enhancements:
- Define mount points for the Quay plugin on the entity image registry page with conditional rendering capabilities