### PR TITLE
chore: Loading 'Register existing component to catalog' software template

### DIFF
--- a/configs/app-config/app-config.yaml
+++ b/configs/app-config/app-config.yaml
@@ -96,6 +96,12 @@ catalog:
       target: https://github.com/redhat-developer/red-hat-developer-hub-software-templates/blob/main/templates/create-backend-plugin/template.yaml
       rules:
         - allow: [Template]
+    # Load 'Register Existing Component to Catalog' Software Template
+    # Using this template in RHDH requires GitHub integration to be set up.
+    - type: url
+      target: https://github.com/redhat-developer/red-hat-developer-hub-software-templates/blob/main/templates/github/register-component/template.yaml
+      rules:
+        - allow: [Template]
     # - type: url
     #   target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all.yaml
     #   rules:

--- a/configs/app-config/app-config.yaml
+++ b/configs/app-config/app-config.yaml
@@ -90,13 +90,13 @@ catalog:
       target: https://github.com/redhat-developer/red-hat-developer-hub-software-templates/blob/main/templates/create-frontend-plugin/template.yaml
       rules:
         - allow: [Template]
-    # Load Backend Dynamic Plugin Software Template
+    # Load Backend Dynamic Plugin Software Template.
     # Using this template in RHDH requires GitHub integration to be set up.
     - type: url
       target: https://github.com/redhat-developer/red-hat-developer-hub-software-templates/blob/main/templates/create-backend-plugin/template.yaml
       rules:
         - allow: [Template]
-    # Load 'Register Existing Component to Catalog' Software Template
+    # Load 'Register Existing Component to Catalog' Software Template.
     # Using this template in RHDH requires GitHub integration to be set up.
     - type: url
       target: https://github.com/redhat-developer/red-hat-developer-hub-software-templates/blob/main/templates/github/register-component/template.yaml


### PR DESCRIPTION
## Description

Loading 'Register existing component to catalog' software template

## Which issue(s) does this PR fix or relate to

- [RHIDP-8546](https://issues.redhat.com/browse/RHIDP-8546)

## PR acceptance criteria

- [x] Tests
- [x] Documentation

## Summary by Sourcery

New Features:
- Add 'Register Existing Component to Catalog' software template entry to the catalog configuration