### PR TITLE
chore: initial Qodo configuration

### DIFF
--- a/.github/workflows/toml-checks.yaml
+++ b/.github/workflows/toml-checks.yaml
@@ -1,0 +1,21 @@
+name: PR TOML Validator
+
+on:
+  push:
+    paths:
+      - '**.toml'
+  pull_request:
+    paths:
+      - '**.toml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      - uses: tombi-toml/setup-tombi@31299123992b4a61821319e63752aaee8fd7996a # v1
+        with:
+          version: 'v0.6.3'
+          checksum: '85fbd6ab07c6faf2cc6d5c826c8a16255e10b5bc391621d391a76e9323124a4c'
+      - name: Validate TOML files
+        run: tombi lint

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,38 @@
+[jira]
+jira_api_token = "${{ secrets.JIRA_API_TOKEN }}"
+jira_base_url = "https://issues.redhat.com"
+
+[github_app]
+# what should be launched automatically
+pr_commands = [
+    "/review",
+    "/describe --pr_description.final_update_message=false",
+    "/improve",
+]
+feedback_on_draft_pr = true
+
+[pr_reviewer] # /review #
+persistent_comment = true
+require_tests_review = false
+require_ticket_analysis_review = true
+enable_review_labels_security = true
+enable_review_labels_effort = true
+
+[pr_description] # /describe #
+enable_pr_diagram = false
+publish_labels = true
+final_update_message = true
+# without this, it can interfere with Sourcery AI
+publish_description_as_comment = true
+publish_description_as_comment_persistent = true
+add_original_user_description = false
+
+[pr_code_suggestions]
+commitable_code_suggestions = false
+
+[config]
+ignore_pr_authors = ["renovate","openshift-cherrypick-robot","rhdh-bot"]
+
+[rag_arguments]
+enable_rag=true
+rag_repo_list=['redhat-developer/rhdh','redhat-developer/red-hat-developers-documentation-rhdh','redhat-developer/rhdh-operator','redhat-developer/rhdh-chart']


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
<!--
Please explain the changes you made here.
-->
Apply changes as in https://github.com/redhat-developer/rhdh-chart/pull/240

- Add Qodo PR agent configuration file
- Set up Jira integration with API token
- Description as comment, instead of updating the PR description (default config can interfere with Sourcery AI and it looks messier).
- Disable the diagram
- Automatically apply labels to the PR according to the type
- Keep the code suggestions in one comment instead of inline suggestions.
- Don't trigger Qodo for bot PRs.

Configuration can be found in their docs:

- [docs.qodo.ai/qodo-documentation/qodo-merge/configuration/configuration-file](https://docs.qodo.ai/qodo-documentation/qodo-merge/configuration/configuration-file)
- [docs.qodo.ai/qodo-documentation/qodo-merge/tools/tools-list](https://docs.qodo.ai/qodo-documentation/qodo-merge/tools/tools-list)

## Which issue(s) does this PR fix or relate to

- Fixes https://issues.redhat.com/browse/RHIDP-8718

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

## Summary by Sourcery

Add initial Qodo PR agent configuration and set up CI checks for TOML validation.

Enhancements:
- Add .pr_agent.toml with Jira integration, GitHub app commands, reviewer settings, PR description options, code suggestions, ignored authors, and RAG arguments

CI:
- Introduce a GitHub Actions workflow to validate TOML files using tombi lint on push and pull requests