### PR TITLE
Add missing analytics section to app-config.local.example.yaml (fix R…

### DIFF
--- a/configs/app-config/app-config.local.example.yaml
+++ b/configs/app-config/app-config.local.example.yaml
@@ -10,6 +10,11 @@
 app:
   title: Red Hat Developer Hub
   baseUrl: ${BASE_URL}
+  analytics:
+    adoptionInsights:
+      enabled: false
+    segment:
+      writeKey: ""
   branding:
     # If using a different logo, replace these lines with your own image(s)
     # fullLogo: data:image/svg+xml;base64,your-image-goes-here==


### PR DESCRIPTION
…HIDP-9100)

<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
Adds the missing analytics section to app-config.local.example.yaml.
Without it, the application fails to start due to schema validation error.

## Which issue(s) does this PR fix or relate to

- Fixes #RHIDP-9100

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer

1. Clone this repo
2. Copy the example config files
3. Run podman compose up
→ With this change, startup succeeds without manual edits.
