### PR TITLE
ci: Fix duplicate job names and logging in CI checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
           - name: "developer-lightspeed"
             cliArgs: "-f compose.yaml -f developer-lightspeed/compose-with-ollama.yaml"
 
-    name: "${{ matrix.tool }} compose - ${{ matrix.composeConfig.name }}"
+    name: "${{ matrix.tool }} compose - ${{ matrix.composeConfig.name }}${{ matrix.userConfig == 'true' && ' - user config' || '' }}"
     runs-on: ubuntu-latest
     env:
       # The default corporate proxy image is located on registry.redhat.io, which requires authentication.
@@ -70,10 +70,13 @@ jobs:
 
     - name: Add user-specific configuration
       if: ${{ matrix.userConfig == 'true' }}
+      env:
+        # https://docs.github.com/en/actions/how-tos/monitor-workflows/enable-debug-logging#enabling-runner-diagnostic-logging
+        LOG_LEVEL: ${{ vars.ACTIONS_RUNNER_DEBUG == 'true' && 'debug' || 'info' }}
       run: |
         # Custom .env file
         cat <<EOF > .env
-        LOG_LEVEL=debug
+        LOG_LEVEL=${{ env.LOG_LEVEL }}
         ROARR_LOG=true
         NODE_DEBUG=fetch
 


### PR DESCRIPTION
## Description
We used to see duplicate job names in the CI checks (for different values of `userConfig` in the matrix), which could be confusing. This also conditionally sets the LOG_LEVEL to `debug` if the runner diagnostic logging is enabled via the `ACTIONS_RUNNER_DEBUG` repo variable [1]

[1] https://docs.github.com/en/actions/how-tos/monitor-workflows/enable-debug-logging#enabling-runner-diagnostic-logging

## Which issue(s) does this PR fix or relate to

&mdash;

## PR acceptance criteria

- [ ] Tests updated and passing
- [ ] Documentation updated
- [ ] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
