### PR TITLE
ci: Display Compose logs in a deterministic order

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,9 @@ jobs:
       run: |
         pip3 install podman-compose=="${PODMAN_COMPOSE_VERSION}"
 
+    - name: Compose config
+      run: ${{ matrix.tool }} compose ${{ matrix.composeConfig.cliArgs }} config
+
     - name: Add user-specific configuration
       if: ${{ matrix.userConfig == 'true' }}
       env:
@@ -139,7 +142,13 @@ jobs:
 
     - name: Compose logs
       if: always()
-      run: ${{ matrix.tool }} compose ${{ matrix.composeConfig.cliArgs }} logs
+      run: |
+        for svc in $(${{ matrix.tool }} compose ${{ matrix.composeConfig.cliArgs }} config --services | sort); do
+          echo "=== $svc ==="
+          ${{ matrix.tool }} compose ${{ matrix.composeConfig.cliArgs }} logs --timestamps "$svc" || true
+          echo "============"
+          echo
+        done
 
     - name: Tear down
       if: always()


### PR DESCRIPTION
## Description
By default, both 'podman compose logs' and 'docker compose logs' interleave log lines chronologically across all services, which can make things messy and hard to troubleshoot when multiple containers are active.
Example: https://github.com/redhat-developer/rhdh-local/actions/runs/18665501932/job/53248550724?pr=111#step:8:41

## Which issue(s) does this PR fix or relate to

&mdash;

## PR acceptance criteria

- [ ] Tests updated and passing
- [ ] Documentation updated
- [ ] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
