### PR TITLE
update csp rules required for scaffolder actions

### DIFF
--- a/developer-lightspeed/configs/app-config/app-config.lightspeed.local.example.yaml
+++ b/developer-lightspeed/configs/app-config/app-config.lightspeed.local.example.yaml
@@ -10,6 +10,7 @@ backend:
 
    script-src:
      - "'self'"
+     - "'unsafe-eval'" # this is required for scaffolder usage, and ajv validation.
      - https://cdn.jsdelivr.net
 # Check out the below guide for more information.
 # Lightspeed on rhdh-local: https://github.com/redhat-developer/rhdh-local/blob/main/developer-lightspeed/README.md


### PR DESCRIPTION
## Description
<!--
Please explain the changes you made here.
-->

Adding csp rules that is required for scaffolder and ajv validation. Without this rule, if you start podman with lightspeed configuration, the scaffolder actions isn't working.



Refer this backstage [config](https://github.com/backstage/backstage/blob/ad498a2236d825973d134b50961cc3a31015e54c/plugins/api-docs/README.md?plain=1#L170C20-L170C81).



