### PR TITLE
feat(lightspeed): add vertex provider to enable google models

### DIFF
--- a/default.env
+++ b/default.env
@@ -47,6 +47,7 @@ SEGMENT_WRITE_KEY=gGVM6sYRK0D0ndVX22BOtS7NRcxPej8t
 ## E.g. ENABLE_OPENAI=
 ENABLE_VLLM=
 ENABLE_OPENAI=
+ENABLE_VERTEX_AI=
 
 # vLLM Inference Settings
 VLLM_URL=
@@ -57,6 +58,14 @@ VLLM_TLS_VERIFY=
 
 # OpenAI Inference Settings
 OPENAI_API_KEY=
+
+# Vertex AI Inference Settings
+## Set ENABLE_VERTEX_AI=true to enable Vertex AI provider
+## Set VERTEX_AI_CREDENTIALS_PATH to the absolute path of your Google Cloud credentials JSON file
+## E.g. VERTEX_AI_CREDENTIALS_PATH=/Users/username/Downloads/your-project-credentials.json
+VERTEX_AI_CREDENTIALS_PATH=
+VERTEX_AI_PROJECT=
+VERTEX_AI_LOCATION=
 
 # Ollama Inference Settings
 OLLAMA_URL=http://ollama:11434/v1

--- a/developer-lightspeed/README.md
+++ b/developer-lightspeed/README.md
@@ -71,6 +71,28 @@ Follow these steps to configure and launch Developer Lightspeed.
     OPENAI_API_KEY=<your-api-key>
     ```
 
+    **Enabling Vertex AI (Gemini)** ⚠️ *Experimental*
+    
+    > [!WARNING]
+    > **Experimental Feature:** Using Vertex AI to run Google models is experimental. Vertex AI provides an OpenAI-compatible API for Gemini models, which is why it can work with Developer Lightspeed (which supports OpenAI API implementations). This is provided as an alternative way to access Google models since `remote:gemini` is not yet fully supported.
+    
+    ```env
+    ENABLE_VERTEX_AI=true
+    VERTEX_AI_CREDENTIALS_PATH=/absolute/path/to/your/google-cloud-credentials.json
+    VERTEX_AI_PROJECT=<your-gcp-project-id>
+    VERTEX_AI_LOCATION=<your-gcp-location> # Optional
+    ```
+    
+    > [!NOTE]
+    > To use Vertex AI, you need:
+    > 1. A Google Cloud Platform (GCP) project with Vertex AI API enabled
+    > 2. A service account with appropriate permissions
+    > 3. A service account key file (JSON) downloaded from GCP
+    > 4. Set `VERTEX_AI_PROJECT` to the project id
+    > 5. Set `VERTEX_AI_CREDENTIALS_PATH` to the absolute path of your credentials JSON file
+    > 
+    > **Read more about configuration and available models:** [Vertex AI Provider Documentation](https://llamastack.github.io/v0.2.18/providers/inference/remote_vertexai.html)
+
     **Preparing For External Provider Question Validation**
     ```env
     ## Ensure VALIDATION_PROVIDER is one of your enabled Inference Providers

--- a/developer-lightspeed/compose-with-validation.yaml
+++ b/developer-lightspeed/compose-with-validation.yaml
@@ -4,3 +4,4 @@ services:
       - ./developer-lightspeed/configs/extra-files/run.yaml:/app-root/run.yaml:Z
       - rag_embeddings:/app-root/embeddings_model
       - rag_vector_db:/app-root/vector_db
+      - ${VERTEX_AI_CREDENTIALS_PATH:-/dev/null}:/app-root/credentials.json:Z

--- a/developer-lightspeed/compose.yaml
+++ b/developer-lightspeed/compose.yaml
@@ -36,6 +36,10 @@ services:
       - ./developer-lightspeed/configs/extra-files/run-no-validation.yaml:/app-root/run.yaml:Z
       - rag_embeddings:/app-root/embeddings_model
       - rag_vector_db:/app-root/vector_db
+      # Set VERTEX_AI_CREDENTIALS_PATH in your .env file to your Google Cloud credentials JSON file path
+      - ${VERTEX_AI_CREDENTIALS_PATH:-/dev/null}:/app-root/credentials.json:Z
+    environment:
+      GOOGLE_APPLICATION_CREDENTIALS: /app-root/credentials.json
     env_file:
       - path: "./default.env"
         required: true

--- a/developer-lightspeed/configs/extra-files/run-no-validation.yaml
+++ b/developer-lightspeed/configs/extra-files/run-no-validation.yaml
@@ -76,6 +76,11 @@ providers:
       provider_type: remote::openai
       config:
         api_key: ${env.OPENAI_API_KEY:=token}
+    - provider_id: ${env.ENABLE_VERTEX_AI:+vertexai}
+      provider_type: remote::vertexai
+      config:
+        project: ${env.VERTEX_AI_PROJECT:=}
+        location: ${env.VERTEX_AI_LOCATION:=us-central1}
     - provider_id: sentence-transformers
       provider_type: inline::sentence-transformers
       config: {}

--- a/developer-lightspeed/configs/extra-files/run.yaml
+++ b/developer-lightspeed/configs/extra-files/run.yaml
@@ -76,6 +76,11 @@ providers:
       provider_type: remote::openai
       config:
         api_key: ${env.OPENAI_API_KEY:=token}
+    - provider_id: ${env.ENABLE_VERTEX_AI:+vertexai}
+      provider_type: remote::vertexai
+      config:
+        project: ${env.VERTEX_AI_PROJECT:=}
+        location: ${env.VERTEX_AI_LOCATION:=us-central1}
     - provider_id: sentence-transformers
       provider_type: inline::sentence-transformers
       config: {}


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
<!--
Please explain the changes you made here.
-->


Add `vertex` provider to support Gemini models in Developer lightspeed.


## Which issue(s) does this PR fix or relate to

- https://issues.redhat.com/browse/RHDHSUPP-301
- https://issues.redhat.com/browse/RHDHBUGS-2313

## PR acceptance criteria

- [ ] Tests updated and passing
- [x] Documentation updated
- [ ] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

Enable vertex and set the following ENV variables and start the lightspeed application.

    ENABLE_VERTEX_AI=true
    VERTEX_AI_CREDENTIALS_PATH=/absolute/path/to/your/google-cloud-credentials.json
    VERTEX_AI_PROJECT=<your-gcp-project-id>
    VERTEX_AI_LOCATION=<your-gcp-location> # Optional



