### PR TITLE
fix: add volume for extension catalog entities [RHIDP-11294]

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -69,7 +69,7 @@ services:
       - ./local-plugins:/opt/app-root/src/local-plugins:Z
       - ./configs:/opt/app-root/src/configs:Z
       - dynamic-plugins-root:/dynamic-plugins-root
-      - extensions-catalog:/extensions
+      - extensions-catalog:${CATALOG_ENTITIES_EXTRACT_DIR:-/extensions}
 
 volumes:
   dynamic-plugins-root:

--- a/compose.yaml
+++ b/compose.yaml
@@ -44,6 +44,7 @@ services:
       - ./wait-for-plugins-and-start.sh:/opt/app-root/src/wait-for-plugins-and-start.sh:Z
       - ./configs:/opt/app-root/src/configs:Z
       - dynamic-plugins-root:/opt/app-root/src/dynamic-plugins-root
+      - extensions-catalog:/extensions
     depends_on:
       install-dynamic-plugins:
         condition: service_completed_successfully
@@ -68,6 +69,8 @@ services:
       - ./local-plugins:/opt/app-root/src/local-plugins:Z
       - ./configs:/opt/app-root/src/configs:Z
       - dynamic-plugins-root:/dynamic-plugins-root
+      - extensions-catalog:/extensions
 
 volumes:
   dynamic-plugins-root:
+  extensions-catalog:

--- a/default.env
+++ b/default.env
@@ -15,6 +15,10 @@ BASE_URL=http://localhost:7007
 # Requires RHDH 1.9+ to be handled.
 CATALOG_INDEX_IMAGE=quay.io/rhdh/plugin-catalog-index:1.9
 
+# Path in the install-dynamic-plugins container where the extensions catalog entities should be extracted to, from the catalog index image
+# Requires RHDH 1.9+ to be handled
+CATALOG_ENTITIES_EXTRACT_DIR=/extensions
+
 # GitHub auth (you need to uncomment github auth section in configs/app-config.local.yaml to enable this)
 #AUTH_GITHUB_CLIENT_ID=
 #AUTH_GITHUB_CLIENT_SECRET=


### PR DESCRIPTION
## Description

As discussed in https://redhat-internal.slack.com/archives/C04CUSD4JSG/p1767790419980379, we need to extract the catalog entities from the index image to the `/marketplace` (to be replaced by `/extensions` in https://github.com/redhat-developer/rhdh-plugins/pull/2006) folder, so that the extensions backend providers can automatically discover them. Otherwise, there are no plugins displayed in the RHDH Extensions UI.

https://github.com/redhat-developer/rhdh/pull/3970 added support for specifying the extraction dir via a new `CATALOG_ENTITIES_EXTRACT_DIR` env var, which we now need to set in the Install Methods (and additionally add the right volume mounts - we cannot create that folder right in the main container because the root filesystem is read-only for security purposes).

On hold until https://github.com/redhat-developer/rhdh/pull/3988 is merged.

## Which issue(s) does this PR fix or relate to

- Fixes https://issues.redhat.com/browse/RHIDP-11294

## PR acceptance criteria

- [ ] Tests updated and passing
- [ ] Documentation updated
- [ ] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

## How to test changes / Special notes to the reviewer

NOTE: requires the `next` RHDH image tag.

**Before**

<img width="1709" height="898" alt="image" src="https://github.com/user-attachments/assets/7642996f-46f6-4a13-b4ba-d9f77328a1bb" />


**With the changes here**

<img width="1882" height="909" alt="image" src="https://github.com/user-attachments/assets/e82b7a0b-c872-4cfc-9d71-61e9914e5fba" />
