### PR TITLE
fix: Fix the dynamic plugins configuration to work with RHDH 1.9+ [RHDHBUGS-2646]

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,26 @@ To browse the existing issues, you can use this [Query](https://issues.redhat.co
 
 Contributions are welcome!
 
+
+## Breaking changes and known issues
+
+### Upgrading to RHDH 1.9
+
+If you switch your `RHDH_IMAGE` to 1.9+ (default value in this branch), you may need to:
+
+1. **Update your `dynamic-plugins.override.yaml`**
+
+Some plugins are no longer bundled in the RHDH image, but have been moved to OCI references.
+
+The official RHDH 1.9 documentation is still being updated to provide clear migration instructions. In the meantime, please refer to https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-1782/plugins-rhdh-reference/#community-plugins-migration-table
+
+Also see [configs/dynamic-plugins/dynamic-plugins.override.example.yaml](configs/dynamic-plugins/dynamic-plugins.override.example.yaml) for an example.
+
+2. **Update any scaffolder modules**
+
+Ensure they are built for the Backstage version used in RHDH 1.9. Otherwise the backend may fail to start (e.g. `TypeError: Cannot read properties of undefined (reading 'id')`). See [RHDHBUGS-2497](https://issues.redhat.com/browse/RHDHBUGS-2497) as a known issue.
+
+
 ## License
 
 ```txt

--- a/compose-with-corporate-proxy.yaml
+++ b/compose-with-corporate-proxy.yaml
@@ -22,6 +22,11 @@ services:
     networks:
       - internal_net
       - default
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/127.0.0.1/3128'"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   rhdh:
     environment:
@@ -36,6 +41,9 @@ services:
       # As a workaround, we are adding it to the default network,
       # but note that there is as such nothing preventing requests from bypassing the proxy to reach the outside.
       - default
+    depends_on:
+      proxy:
+        condition: service_healthy
 
   install-dynamic-plugins:
     environment:
@@ -44,3 +52,6 @@ services:
       # NO_PROXY configured in the .env file, but can be overridden here
     networks:
       - internal_net
+    depends_on:
+      proxy:
+        condition: service_healthy

--- a/compose.yaml
+++ b/compose.yaml
@@ -23,7 +23,7 @@ services:
 
   rhdh:
     container_name: rhdh
-    image: ${RHDH_IMAGE:-quay.io/rhdh-community/rhdh:1.8}
+    image: ${RHDH_IMAGE:-quay.io/rhdh-community/rhdh:next-1.9}
     env_file:
       - path: "./default.env"
         required: true
@@ -53,7 +53,7 @@ services:
 
   install-dynamic-plugins:
     container_name: rhdh-plugins-installer
-    image: ${RHDH_IMAGE:-quay.io/rhdh-community/rhdh:1.8}
+    image: ${RHDH_IMAGE:-quay.io/rhdh-community/rhdh:next-1.9}
     # docker compose volumes are owned by root, so we need to run as root to write to them
     # the main rhdh container will be able to read from this as files are world readable
     user: "root"

--- a/compose.yaml
+++ b/compose.yaml
@@ -42,7 +42,7 @@ services:
       - ./docs:/opt/app-root/src/docs:Z
       - ./catalog-info.yaml:/opt/app-root/src/catalog-info.yaml:Z
       - ./wait-for-plugins-and-start.sh:/opt/app-root/src/wait-for-plugins-and-start.sh:Z
-      - ./configs:/opt/app-root/src/configs:Z
+      - ./configs:/opt/app-root/src/configs:z
       - dynamic-plugins-root:/opt/app-root/src/dynamic-plugins-root
       - extensions-catalog:/extensions
     depends_on:
@@ -67,7 +67,7 @@ services:
     volumes:
       - ./prepare-and-install-dynamic-plugins.sh:/opt/app-root/src/prepare-and-install-dynamic-plugins.sh:Z
       - ./local-plugins:/opt/app-root/src/local-plugins:Z
-      - ./configs:/opt/app-root/src/configs:Z
+      - ./configs:/opt/app-root/src/configs:z
       - dynamic-plugins-root:/dynamic-plugins-root
       - extensions-catalog:${CATALOG_ENTITIES_EXTRACT_DIR:-/extensions}
 

--- a/configs/dynamic-plugins/dynamic-plugins.override.example.yaml
+++ b/configs/dynamic-plugins/dynamic-plugins.override.example.yaml
@@ -3,7 +3,7 @@
 
 includes:
   - dynamic-plugins.default.yaml
-  # Uncomment the following line (and the corresponding 'red-hat-developer-hub-backstage-plugin-marketplace*' plugins)
+  # Uncomment the following line (and the corresponding 'red-hat-developer-hub-backstage-plugin-extensions*' plugins)
   # to enable dynamic plugins installation using the Extensions UI.
   # - /dynamic-plugins-root/dynamic-plugins.extensions.yaml
 
@@ -98,11 +98,12 @@ includes:
 #                 importName: RbacPage
 
 # # Uncomment the following two plugins to enable dynamic plugins installation via the Extensions UI
+# # TODO: Replace the `./dynamic-plugins/dist/` path with the OCI reference once we switch to that in the dynamic-plugins.default.yaml (DPDY) file in the catalog index image - see https://issues.redhat.com/browse/RHDHPLAN-934 and https://issues.redhat.com/browse/RHDHPLAN-256
 # # - package: 'oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-extensions:{{inherit}}'
 # - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions
 #   disabled: false
 
-# # TODO: Uncomment the OCI reference once it is uncommented in the DPDY in the catalog index image
+# # TODO: Replace the `./dynamic-plugins/dist/` path with the OCI reference once we switch to that in the dynamic-plugins.default.yaml (DPDY) file in the catalog index image - see https://issues.redhat.com/browse/RHDHPLAN-934 and https://issues.redhat.com/browse/RHDHPLAN-256
 # # - package: 'oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-extensions-backend:{{inherit}}'
 # - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions-backend-dynamic
 #   disabled: false

--- a/configs/dynamic-plugins/dynamic-plugins.override.example.yaml
+++ b/configs/dynamic-plugins/dynamic-plugins.override.example.yaml
@@ -98,30 +98,13 @@ includes:
 #                 importName: RbacPage
 
 # # Uncomment the following two plugins to enable dynamic plugins installation via the Extensions UI
-# - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-marketplace
+# # - package: 'oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-extensions:{{inherit}}'
+# - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions
 #   disabled: false
-#   pluginConfig:
-#     dynamicPlugins:
-#       frontend:
-#         red-hat-developer-hub.backstage-plugin-marketplace:
-#           translationResources:
-#             - importName: marketplaceTranslations
-#               ref: marketplaceTranslationRef
-#               module: Alpha
-#           appIcons:
-#             - name: pluginsIcon
-#               importName: PluginsIcon
-#           dynamicRoutes:
-#             - path: /extensions
-#               importName: DynamicMarketplacePluginRouter
-#               menuItem:
-#                 icon: pluginsIcon
-#                 text: Extensions
-#                 textKey: menuItem.extensions
-#           menuItems:
-#             extensions:
-#               parent: default.admin
-# - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-marketplace-backend-dynamic
+
+# # TODO: Uncomment the OCI reference once it is uncommented in the DPDY in the catalog index image
+# # - package: 'oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-extensions-backend:{{inherit}}'
+# - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions-backend-dynamic
 #   disabled: false
 #   pluginConfig:
 #     extensions:

--- a/configs/dynamic-plugins/dynamic-plugins.yaml
+++ b/configs/dynamic-plugins/dynamic-plugins.yaml
@@ -6,12 +6,13 @@ includes:
 
 plugins:
   # Tech Radar frontend plugin
-  # TODO: Uncomment the OCI reference once it is uncommented in the DPDY in the catalog index image
+# # TODO: Replace the `./dynamic-plugins/dist/` path with the OCI reference once we switch to that in the dynamic-plugins.default.yaml (DPDY) file in the catalog index image - see https://issues.redhat.com/browse/RHDHPLAN-934 and https://issues.redhat.com/browse/RHDHPLAN-256
   # - package: 'oci://quay.io/rhdh/backstage-community-plugin-tech-radar:{{inherit}}'
   - package: ./dynamic-plugins/dist/backstage-community-plugin-tech-radar
     disabled: false
 
   # Quay plugin
+# # TODO: Replace the `./dynamic-plugins/dist/` path with the OCI reference once we switch to that in the dynamic-plugins.default.yaml (DPDY) file in the catalog index image - see https://issues.redhat.com/browse/RHDHPLAN-934 and https://issues.redhat.com/browse/RHDHPLAN-256
   # - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay-backend:{{inherit}}'
   #   disabled: false
   - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay:{{inherit}}'
@@ -22,7 +23,7 @@ plugins:
     disabled: false
 
   # Floating Action Button plugin with submenu actions
-  # TODO: Uncomment the OCI reference once it is uncommented in the DPDY in the catalog index image
+  # TODO: Replace the `./dynamic-plugins/dist/` path with the OCI reference once we switch to that in the dynamic-plugins.default.yaml (DPDY) file in the catalog index image - see https://issues.redhat.com/browse/RHDHPLAN-934 and https://issues.redhat.com/browse/RHDHPLAN-256
   # - package: 'oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-global-floating-action-button:{{inherit}}'
   - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-global-floating-action-button
     disabled: false
@@ -65,12 +66,12 @@ plugins:
   # Enable dynamic plugins installation by using Extensions
   #########################################################
 
-  # TODO: Uncomment the OCI reference once it is uncommented in the DPDY in the catalog index image
+  # TODO: Replace the `./dynamic-plugins/dist/` path with the OCI reference once we switch to that in the dynamic-plugins.default.yaml (DPDY) file in the catalog index image - see https://issues.redhat.com/browse/RHDHPLAN-934 and https://issues.redhat.com/browse/RHDHPLAN-256
   # - package: 'oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-extensions:{{inherit}}'
   - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions
     disabled: false
 
-  # TODO: Uncomment the OCI reference once it is uncommented in the DPDY in the catalog index image
+  # TODO: Replace the `./dynamic-plugins/dist/` path with the OCI reference once we switch to that in the dynamic-plugins.default.yaml (DPDY) file in the catalog index image - see https://issues.redhat.com/browse/RHDHPLAN-934 and https://issues.redhat.com/browse/RHDHPLAN-256
   # - package: 'oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-extensions-backend:{{inherit}}'
   - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions-backend-dynamic
     disabled: false

--- a/configs/dynamic-plugins/dynamic-plugins.yaml
+++ b/configs/dynamic-plugins/dynamic-plugins.yaml
@@ -6,11 +6,15 @@ includes:
 
 plugins:
   # Tech Radar frontend plugin
+  # TODO: Uncomment the OCI reference once it is uncommented in the DPDY in the catalog index image
+  # - package: 'oci://quay.io/rhdh/backstage-community-plugin-tech-radar:{{inherit}}'
   - package: ./dynamic-plugins/dist/backstage-community-plugin-tech-radar
     disabled: false
 
   # Quay plugin
-  - package: ./dynamic-plugins/dist/backstage-community-plugin-quay
+  # - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay-backend:{{inherit}}'
+  #   disabled: false
+  - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay:{{inherit}}'
     disabled: false
 
   # Scaffolder Github plugin - used by Dynamic Plugin Software Templates
@@ -18,6 +22,8 @@ plugins:
     disabled: false
 
   # Floating Action Button plugin with submenu actions
+  # TODO: Uncomment the OCI reference once it is uncommented in the DPDY in the catalog index image
+  # - package: 'oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-global-floating-action-button:{{inherit}}'
   - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-global-floating-action-button
     disabled: false
     pluginConfig:
@@ -58,31 +64,15 @@ plugins:
   #########################################################
   # Enable dynamic plugins installation by using Extensions
   #########################################################
-  - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-marketplace
-    disabled: false
-    pluginConfig:
-      dynamicPlugins:
-        frontend:
-          red-hat-developer-hub.backstage-plugin-marketplace:
-            translationResources:
-              - importName: marketplaceTranslations
-                ref: marketplaceTranslationRef
-                module: Alpha
-            appIcons:
-              - name: pluginsIcon
-                importName: PluginsIcon
-            dynamicRoutes:
-              - path: /extensions
-                importName: DynamicMarketplacePluginRouter
-                menuItem:
-                  icon: pluginsIcon
-                  text: Extensions
-                  textKey: menuItem.extensions
-            menuItems:
-              extensions:
-                parent: default.admin
 
-  - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-marketplace-backend-dynamic
+  # TODO: Uncomment the OCI reference once it is uncommented in the DPDY in the catalog index image
+  # - package: 'oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-extensions:{{inherit}}'
+  - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions
+    disabled: false
+
+  # TODO: Uncomment the OCI reference once it is uncommented in the DPDY in the catalog index image
+  # - package: 'oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-extensions-backend:{{inherit}}'
+  - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions-backend-dynamic
     disabled: false
     pluginConfig:
       extensions:

--- a/default.env
+++ b/default.env
@@ -46,7 +46,7 @@ SEGMENT_WRITE_KEY=gGVM6sYRK0D0ndVX22BOtS7NRcxPej8t
 
 # NO_PROXY will take effect only if HTTP(S)_PROXY env vars are set.
 # See the compose-with-corporate-proxy.yaml file.
-NO_PROXY=localhost,127.0.0.1,quay.io,registry.access.redhat.com
+#NO_PROXY=localhost,127.0.0.1
 
 # ==============================================================================
 # Developer Lightspeed Configuration

--- a/default.env
+++ b/default.env
@@ -46,7 +46,7 @@ SEGMENT_WRITE_KEY=gGVM6sYRK0D0ndVX22BOtS7NRcxPej8t
 
 # NO_PROXY will take effect only if HTTP(S)_PROXY env vars are set.
 # See the compose-with-corporate-proxy.yaml file.
-#NO_PROXY=localhost,127.0.0.1
+NO_PROXY=localhost,127.0.0.1,quay.io,registry.access.redhat.com
 
 # ==============================================================================
 # Developer Lightspeed Configuration

--- a/developer-lightspeed/configs/dynamic-plugins/dynamic-plugins.lightspeed.yaml
+++ b/developer-lightspeed/configs/dynamic-plugins/dynamic-plugins.lightspeed.yaml
@@ -4,7 +4,7 @@
 includes:
   - dynamic-plugins.default.yaml
 plugins:
-  - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed:bs_1.42.5__1.0.3!red-hat-developer-hub-backstage-plugin-lightspeed
+  - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed:bs_1.45.3__1.2.3'
     disabled: false
     pluginConfig:
       lightspeed:
@@ -22,16 +22,22 @@ plugins:
               - importName: lightspeedTranslations
                 module: Alpha
                 ref: lightspeedTranslationRef
-            appIcons:
-              - name: LightspeedIcon
-                module: LightspeedPlugin
-                importName: LightspeedIcon
             dynamicRoutes:
               - path: /lightspeed
                 importName: LightspeedPage
-                module: LightspeedPlugin
-                menuItem:
-                  icon: LightspeedIcon
-                  text: Lightspeed
-  - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed-backend:bs_1.42.5__1.0.3!red-hat-developer-hub-backstage-plugin-lightspeed-backend
+            mountPoints:
+              - mountPoint: application/listener
+                importName: LightspeedFAB
+              - mountPoint: application/provider
+                importName: LightspeedDrawerProvider
+              - mountPoint: application/internal/drawer-state
+                importName: LightspeedDrawerStateExposer
+                config:
+                  id: lightspeed
+              - mountPoint: application/internal/drawer-content
+                importName: LightspeedChatContainer
+                config:
+                  id: lightspeed
+                  priority: 100
+  - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-lightspeed-backend:bs_1.45.3__1.2.2'
     disabled: false

--- a/docs/getting-started-rhdh/comparison.md
+++ b/docs/getting-started-rhdh/comparison.md
@@ -78,7 +78,7 @@ Both platforms share the same foundational features:
 |---------|----------------|------------------------|
 | **Dynamic Plug-Ins** (no need to recompile) | ❌ | ✅ |
 | **Verified Plugin Compatibility** | ⚠️ (self-verify) | ✅ |
-| **Extensions Catalog Plugin** (marketplace) | ❌ | ✅ |
+| **Extensions Catalog Plugin** (catalog) | ❌ | ✅ |
 | **Adoption Insights Plugin** (user metrics) | ❌ | ✅ |
 | **20+ Red Hat Plugins** (e.g., Tekton, ArgoCD, Kiali, 3scale, ACS, Ansible) | ❌ | ✅ |
 | **[Free Software Templates Library](https://github.com/redhat-developer/red-hat-developer-hub-software-templates)** | ❌ | ✅ |

--- a/docs/getting-started-rhdh/extensions.md
+++ b/docs/getting-started-rhdh/extensions.md
@@ -45,10 +45,10 @@ Integrating these entity plugins means you don't have to leave Developer Hub to 
 
 How do you know what plugins are available?
 
-Red Hat Developer Hub includes a built-in [**Extensions**](/extensions) marketplace (sometimes called the "Extensions Plugin") that lists available plugins.
+Red Hat Developer Hub includes a built-in [**Extensions**](/extensions) catalog (sometimes called the "Extensions Plugin") that lists available plugins.
 
 !!! note "For Administrators Only 🔒"
-    The Extensions marketplace is primarily a tool for **Administrators** and **Platform Engineers**. It allows them to see which plugins are installed, which are available, and to manage their configuration.
+    The Extensions catalog is primarily a tool for **Administrators** and **Platform Engineers**. It allows them to see which plugins are installed, which are available, and to manage their configuration.
     
     As a user, you typically won't use this page to "install" plugins yourself. Instead, you'll work with your administrator to request the plugins your team needs.
 

--- a/orchestrator/configs/dynamic-plugins/dynamic-plugins.yaml
+++ b/orchestrator/configs/dynamic-plugins/dynamic-plugins.yaml
@@ -3,40 +3,19 @@ includes:
   - dynamic-plugins.default.yaml
 
 plugins:
-  - package: "https://npm.registry.redhat.com/@redhat/backstage-plugin-orchestrator/-/backstage-plugin-orchestrator-1.8.2.tgz"
-    integrity: sha512-rnUA6iZ2JVAyASfwS4P9HeFmpqCgH6FQouzzg4s6lCPAsYUFvu6tifJ3df5lThXPUTJ2cDvvQgamU+4DiHP2jw==
+  - package: 'oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator:{{inherit}}'
+    disabled: false
+  - package: 'oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator-backend:{{inherit}}'
     disabled: false
     pluginConfig:
-      dynamicPlugins:
-        frontend:
-          red-hat-developer-hub.backstage-plugin-orchestrator:
-            appIcons:
-              - importName: OrchestratorIcon
-                name: orchestratorIcon
-            dynamicRoutes:
-              - importName: OrchestratorPage
-                menuItem:
-                  icon: orchestratorIcon
-                  text: Orchestrator
-                path: /orchestrator
-  - disabled: false
-    package: "https://npm.registry.redhat.com/@redhat/backstage-plugin-orchestrator-backend-dynamic/-/backstage-plugin-orchestrator-backend-dynamic-1.8.2.tgz"
-    integrity: sha512-6G0YguzCM5nCDpOrIGJpLTXVMr6EBdIVqSXtsLH9RvBH25RTuFpfJ7q6eEp26DqveaiqUCfBpJ51smdjcsEzFQ==
+      orchestrator:
+        dataIndexService:
+          url: http://sonataflow:8899
+  - package: 'oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator:{{inherit}}'
+    disabled: false
     pluginConfig:
       orchestrator:
         dataIndexService:
           url: http://sonataflow:8899
-  - disabled: false
-    package: "https://npm.registry.redhat.com/@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic/-/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.8.2.tgz"
-    integrity: sha512-N2hCn9RI/QVEoK56FAkGkSDbvfQCOIzVsJTwDX0kf//npO++2crRSJpB1Lr/m2UtYxfaXZX53p8sPcK3g8yWkQ==
-    pluginConfig:
-      orchestrator:
-        dataIndexService:
-          url: http://sonataflow:8899
-  - disabled: false
-    package: "https://npm.registry.redhat.com/@redhat/backstage-plugin-orchestrator-form-widgets/-/backstage-plugin-orchestrator-form-widgets-1.8.2.tgz"
-    integrity: sha512-Pe0dn3g+YTK3jbl36E8nt4zdyH/3w+MWgRyFWPc2B0eV4/L/aRfRC4KxcktmHPdamRGXTIaXL6cFae8TZl8Htw==
-    pluginConfig:
-      dynamicPlugins:
-        frontend:
-          red-hat-developer-hub.backstage-plugin-orchestrator-form-widgets: {}
+  - package: 'oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets:{{inherit}}'
+    disabled: false


### PR DESCRIPTION
## Description

This adapts the configuration to make it work with RHDH 1.9+. Otherwise, the plugins installer container would fail with errors like below:

<details>
<summary>Logs</summary>

```
rhdh-plugins-installer  | 
rhdh-plugins-installer  | ======= Installing dynamic plugin ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-marketplace
rhdh-plugins-installer  |       ==> Grabbing package archive through `npm pack`
rhdh-plugins-installer  | Traceback (most recent call last):
rhdh-plugins-installer  |   File "/opt/app-root/src/install-dynamic-plugins.py", line 162, in run_command
rhdh-plugins-installer  |     return subprocess.run(
rhdh-plugins-installer  |            ^^^^^^^^^^^^^^^
rhdh-plugins-installer  |   File "/usr/lib64/python3.11/subprocess.py", line 571, in run
rhdh-plugins-installer  |     raise CalledProcessError(retcode, process.args,
rhdh-plugins-installer  | subprocess.CalledProcessError: Command '['npm', 'pack', '/opt/app-root/src/dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-marketplace']' returned non-zero exit status 254.
rhdh-plugins-installer  | 
rhdh-plugins-installer  | During handling of the above exception, another exception occurred:
rhdh-plugins-installer  | 
rhdh-plugins-installer  | Traceback (most recent call last):
rhdh-plugins-installer  |   File "/opt/app-root/src/install-dynamic-plugins.py", line 1284, in <module>
rhdh-plugins-installer  |     main()
rhdh-plugins-installer  |   File "/opt/app-root/src/install-dynamic-plugins.py", line 1269, in main
rhdh-plugins-installer  |     _, plugin_config = install_plugin(plugin, plugin_path_by_hash, dynamic_plugins_root, skip_integrity_check)
rhdh-plugins-installer  |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rhdh-plugins-installer  |   File "/opt/app-root/src/install-dynamic-plugins.py", line 917, in install_plugin
rhdh-plugins-installer  |     plugin_path = installer.install(plugin, plugin_path_by_hash)
rhdh-plugins-installer  |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rhdh-plugins-installer  |   File "/opt/app-root/src/install-dynamic-plugins.py", line 814, in install
rhdh-plugins-installer  |     result = run_command(
rhdh-plugins-installer  |              ^^^^^^^^^^^^
rhdh-plugins-installer  |   File "/opt/app-root/src/install-dynamic-plugins.py", line 179, in run_command
rhdh-plugins-installer  |     raise InstallException(msg)
rhdh-plugins-installer  | InstallException: Error while installing plugin /opt/app-root/src/dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-marketplace with 'npm pack': command failed with exit code 254
rhdh-plugins-installer  | command: npm pack /opt/app-root/src/dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-marketplace
rhdh-plugins-installer  | stderr: npm error code ENOENT
rhdh-plugins-installer  | npm error syscall open
rhdh-plugins-installer  | npm error path /opt/app-root/src/dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-marketplace/package.json
rhdh-plugins-installer  | npm error errno -2
rhdh-plugins-installer  | npm error enoent Could not read package.json: Error: ENOENT: no such file or directory, open '/opt/app-root/src/dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-marketplace/package.json'
rhdh-plugins-installer  | npm error enoent This is related to npm not being able to find a file.
rhdh-plugins-installer  | npm error enoent
rhdh-plugins-installer  | npm error A complete log of this run can be found in: /opt/app-root/src/.npm/_logs/2026-02-11T15_15_26_304Z-debug-0.log
rhdh-plugins-installer  | 
rhdh-plugins-installer  | ======= Cleaning up temporary catalog index directory
rhdh-plugins-installer  | ======= Removed lock file: /dynamic-plugins-root/install-dynamic-plugins.lock
Container rhdh-plugins-installer Error service "install-dynamic-plugins" didn't complete successfully: exit 1
service "install-dynamic-plugins" didn't complete successfully: exit 1
Error: executing /usr/libexec/docker/cli-plugins/docker-compose -f compose.yaml up --force-recreate: exit status 1
```

</details>

## Which issue(s) does this PR fix or relate to

- Fixes https://issues.redhat.com/browse/RHDHBUGS-2646

## PR acceptance criteria

- [x] Tests updated and passing
- [x] Documentation updated
- [x] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

## How to test changes / Special notes to the reviewer

Running `podman|docker compose up` with the `next` RHDH image tag should work as expected:

<img width="1908" height="1122" alt="image" src="https://github.com/user-attachments/assets/4056e6e1-65d8-4de0-bdb6-16e9431a88cc" />

