### PR TITLE
fix: replace marketplace with extensions references for RHDH 1.9+

### DIFF
--- a/configs/dynamic-plugins/dynamic-plugins.override.example.yaml
+++ b/configs/dynamic-plugins/dynamic-plugins.override.example.yaml
@@ -3,7 +3,7 @@
 
 includes:
   - dynamic-plugins.default.yaml
-  # Uncomment the following line (and the corresponding 'red-hat-developer-hub-backstage-plugin-marketplace*' plugins)
+  # Uncomment the following line (and the corresponding 'red-hat-developer-hub-backstage-plugin-extensions*' plugins)
   # to enable dynamic plugins installation using the Extensions UI.
   # - /dynamic-plugins-root/dynamic-plugins.extensions.yaml
 
@@ -98,22 +98,22 @@ includes:
 #                 importName: RbacPage
 
 # # Uncomment the following two plugins to enable dynamic plugins installation via the Extensions UI
-# - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-marketplace
+# - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions
 #   disabled: false
 #   pluginConfig:
 #     dynamicPlugins:
 #       frontend:
-#         red-hat-developer-hub.backstage-plugin-marketplace:
+#         red-hat-developer-hub.backstage-plugin-extensions:
 #           translationResources:
-#             - importName: marketplaceTranslations
-#               ref: marketplaceTranslationRef
+#             - importName: extensionsTranslations
+#               ref: extensionsTranslationRef
 #               module: Alpha
 #           appIcons:
 #             - name: pluginsIcon
 #               importName: PluginsIcon
 #           dynamicRoutes:
 #             - path: /extensions
-#               importName: DynamicMarketplacePluginRouter
+#               importName: DynamicExtensionsPluginRouter
 #               menuItem:
 #                 icon: pluginsIcon
 #                 text: Extensions
@@ -121,7 +121,7 @@ includes:
 #           menuItems:
 #             extensions:
 #               parent: default.admin
-# - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-marketplace-backend-dynamic
+# - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions-backend-dynamic
 #   disabled: false
 #   pluginConfig:
 #     extensions:

--- a/configs/dynamic-plugins/dynamic-plugins.yaml
+++ b/configs/dynamic-plugins/dynamic-plugins.yaml
@@ -58,22 +58,22 @@ plugins:
   #########################################################
   # Enable dynamic plugins installation by using Extensions
   #########################################################
-  - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-marketplace
+  - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions
     disabled: false
     pluginConfig:
       dynamicPlugins:
         frontend:
-          red-hat-developer-hub.backstage-plugin-marketplace:
+          red-hat-developer-hub.backstage-plugin-extensions:
             translationResources:
-              - importName: marketplaceTranslations
-                ref: marketplaceTranslationRef
+              - importName: extensionsTranslations
+                ref: extensionsTranslationRef
                 module: Alpha
             appIcons:
               - name: pluginsIcon
                 importName: PluginsIcon
             dynamicRoutes:
               - path: /extensions
-                importName: DynamicMarketplacePluginRouter
+                importName: DynamicExtensionsPluginRouter
                 menuItem:
                   icon: pluginsIcon
                   text: Extensions
@@ -82,7 +82,7 @@ plugins:
               extensions:
                 parent: default.admin
 
-  - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-marketplace-backend-dynamic
+  - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions-backend-dynamic
     disabled: false
     pluginConfig:
       extensions:

--- a/docs/getting-started-rhdh/comparison.md
+++ b/docs/getting-started-rhdh/comparison.md
@@ -78,7 +78,7 @@ Both platforms share the same foundational features:
 |---------|----------------|------------------------|
 | **Dynamic Plug-Ins** (no need to recompile) | ❌ | ✅ |
 | **Verified Plugin Compatibility** | ⚠️ (self-verify) | ✅ |
-| **Extensions Catalog Plugin** (marketplace) | ❌ | ✅ |
+| **Extensions Catalog Plugin** (catalog) | ❌ | ✅ |
 | **Adoption Insights Plugin** (user metrics) | ❌ | ✅ |
 | **20+ Red Hat Plugins** (e.g., Tekton, ArgoCD, Kiali, 3scale, ACS, Ansible) | ❌ | ✅ |
 | **[Free Software Templates Library](https://github.com/redhat-developer/red-hat-developer-hub-software-templates)** | ❌ | ✅ |

--- a/docs/getting-started-rhdh/extensions.md
+++ b/docs/getting-started-rhdh/extensions.md
@@ -45,10 +45,10 @@ Integrating these entity plugins means you don't have to leave Developer Hub to 
 
 How do you know what plugins are available?
 
-Red Hat Developer Hub includes a built-in [**Extensions**](/extensions) marketplace (sometimes called the "Extensions Plugin") that lists available plugins.
+Red Hat Developer Hub includes a built-in [**Extensions**](/extensions) catalog (sometimes called the "Extensions Plugin") that lists available plugins.
 
 !!! note "For Administrators Only 🔒"
-    The Extensions marketplace is primarily a tool for **Administrators** and **Platform Engineers**. It allows them to see which plugins are installed, which are available, and to manage their configuration.
+    The Extensions catalog is primarily a tool for **Administrators** and **Platform Engineers**. It allows them to see which plugins are installed, which are available, and to manage their configuration.
     
     As a user, you typically won't use this page to "install" plugins yourself. Instead, you'll work with your administrator to request the plugins your team needs.
 


### PR DESCRIPTION
## Description

In RHDH 1.9 the marketplace wrapper was renamed to extensions. This align the configuration with this.

## Which issue(s) does this PR fix or relate to

- Fixes #_issue_number_

## PR acceptance criteria

- [ ] Tests updated and passing
- [ ] Documentation updated
- [ ] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
