### PR TITLE
chore: tagRelease.sh: bump to 1.9.0 in main branch [skip-build] [skip-e2e]

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -23,7 +23,7 @@ services:
 
   rhdh:
     container_name: rhdh
-    image: ${RHDH_IMAGE:-quay.io/rhdh-community/rhdh:1.8}
+    image: ${RHDH_IMAGE:-quay.io/rhdh-community/rhdh:1.9}
     env_file:
       - path: "./default.env"
         required: true
@@ -53,7 +53,7 @@ services:
 
   install-dynamic-plugins:
     container_name: rhdh-plugins-installer
-    image: ${RHDH_IMAGE:-quay.io/rhdh-community/rhdh:1.8}
+    image: ${RHDH_IMAGE:-quay.io/rhdh-community/rhdh:1.9}
     # docker compose volumes are owned by root, so we need to run as root to write to them
     # the main rhdh container will be able to read from this as files are world readable
     user: "root"

--- a/default.env
+++ b/default.env
@@ -9,7 +9,7 @@ BASE_URL=http://localhost:7007
 
 # configure image to use: default to using the latest stable tag of the community builds, which are built for both amd64 and arm64 architectures
 # to use bleeding edge :next images or commercially supported images, see README.md for details
-# RHDH_IMAGE=quay.io/rhdh-community/rhdh:1.8
+# RHDH_IMAGE=quay.io/rhdh-community/rhdh:1.9
 
 # Default plugin catalog index image
 # Requires RHDH 1.9+ to be handled.

--- a/docs/rhdh-local-guide/container-image-guide.md
+++ b/docs/rhdh-local-guide/container-image-guide.md
@@ -41,7 +41,7 @@ NOTE: Only `linux-amd64` builds are currently commercially supported.
 To use the most recent nightly CI build of RHDH 1.y (for example, 1.8), set the variable as follows.
 
 ```sh
-RHDH_IMAGE=quay.io/rhdh/rhdh-hub-rhel9:1.8
+RHDH_IMAGE=quay.io/rhdh/rhdh-hub-rhel9:1.10
 ```
 
 ### Using commercially supported official images


### PR DESCRIPTION
## Summary
- Update rhdh-community/rhdh image refs from 1.8 to 1.9 (GA version)
- Update CI build image ref to 1.10 (next version)
- Part of 1.9.0 GA release tagging process

Note: 1.9.0 tag still needs to be pushed by someone with write access.

Made with [Cursor](https://cursor.com)