### PR TITLE
[release-1.9] Update RHDH_IMAGE version to 1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ If you switch your `RHDH_IMAGE` to 1.9+ (default value in this branch), you may 
 
 Some plugins are no longer bundled in the RHDH image, but have been moved to OCI references.
 
-The official RHDH 1.9 documentation is still being updated to provide clear migration instructions. In the meantime, please refer to https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-1782/plugins-rhdh-reference/#community-plugins-migration-table
+See [Breaking Change in RHDH 1.9](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.9/html/dynamic_plugins_reference/ref-community-plugins-migration_title-plugins-rhdh-about) for clear migration instructions.
 
 Also see [configs/dynamic-plugins/dynamic-plugins.override.example.yaml](configs/dynamic-plugins/dynamic-plugins.override.example.yaml) for an example.
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ If you switch your `RHDH_IMAGE` to 1.9+ (default value in this branch), you may 
 
 Some plugins are no longer bundled in the RHDH image, but have been moved to OCI references.
 
-See [Breaking Change in RHDH 1.9](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.9/html/dynamic_plugins_reference/ref-community-plugins-migration_title-plugins-rhdh-about) for clear migration instructions.
+See [Migration Steps](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.9/html/dynamic_plugins_reference/ref-community-plugins-migration_title-plugins-rhdh-about#migration-steps) for more information.
 
 Also see [configs/dynamic-plugins/dynamic-plugins.override.example.yaml](configs/dynamic-plugins/dynamic-plugins.override.example.yaml) for an example.
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -23,7 +23,7 @@ services:
 
   rhdh:
     container_name: rhdh
-    image: ${RHDH_IMAGE:-quay.io/rhdh-community/rhdh:next-1.9}
+    image: ${RHDH_IMAGE:-quay.io/rhdh-community/rhdh:1.9}
     env_file:
       - path: "./default.env"
         required: true
@@ -53,7 +53,7 @@ services:
 
   install-dynamic-plugins:
     container_name: rhdh-plugins-installer
-    image: ${RHDH_IMAGE:-quay.io/rhdh-community/rhdh:next-1.9}
+    image: ${RHDH_IMAGE:-quay.io/rhdh-community/rhdh:1.9}
     # docker compose volumes are owned by root, so we need to run as root to write to them
     # the main rhdh container will be able to read from this as files are world readable
     user: "root"

--- a/default.env
+++ b/default.env
@@ -9,7 +9,7 @@ BASE_URL=http://localhost:7007
 
 # configure image to use: default to using the latest stable tag of the community builds, which are built for both amd64 and arm64 architectures
 # to use bleeding edge :next images or commercially supported images, see README.md for details
-# RHDH_IMAGE=quay.io/rhdh-community/rhdh:1.8
+# RHDH_IMAGE=quay.io/rhdh-community/rhdh:1.9
 
 # Default plugin catalog index image
 # Requires RHDH 1.9+ to be handled.


### PR DESCRIPTION
## Description

For consistency with the other branches, now that we have a `1.9` tag. `next-1.9` was only there for testing the pre-releases.

## Which issue(s) does this PR fix or relate to

&mdash;

## PR acceptance criteria

- [ ] Tests updated and passing
- [ ] Documentation updated
- [ ] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
