### PR TITLE
Revert "[release-1.8] feat: bumping orchestrator plugins to 1.8.10 (#…

### DIFF
--- a/orchestrator/configs/dynamic-plugins/dynamic-plugins.yaml
+++ b/orchestrator/configs/dynamic-plugins/dynamic-plugins.yaml
@@ -3,8 +3,8 @@ includes:
   - dynamic-plugins.default.yaml
 
 plugins:
-  - package: "https://npm.registry.redhat.com/@redhat/backstage-plugin-orchestrator/-/backstage-plugin-orchestrator-1.8.10.tgz"
-    integrity: sha512-Tlqs2s4WuzM0QQTvgpIxSj0YPA5Lhr0ahMrEXwu0NRnlehNjJjl6NCZObjKATftcOmYRzBlMaC4JMvTOWNFDlA==
+  - package: "https://npm.registry.redhat.com/@redhat/backstage-plugin-orchestrator/-/backstage-plugin-orchestrator-1.8.9.tgz"
+    integrity: sha512-k9r4xEfy3a5En1DTBZkzjhbUVFfbP8Pb+/uCkTXwqqwDJaM2ZzPMzaMj4x65XBnpKTdEZJA0rf/mFMFnfM8I6w==
     disabled: false
     pluginConfig:
       dynamicPlugins:
@@ -20,22 +20,22 @@ plugins:
                   text: Orchestrator
                 path: /orchestrator
   - disabled: false
-    package: "https://npm.registry.redhat.com/@redhat/backstage-plugin-orchestrator-backend-dynamic/-/backstage-plugin-orchestrator-backend-dynamic-1.8.10.tgz"
-    integrity: sha512-dRozMLDbj7AYgX4StT53rQ7OqnSx7gn4Js4z/1eZoPAuFm1T/4zwjoOWGJxmmNNPH1pFpeopT8Kc3VVVsWrYeA==
+    package: "https://npm.registry.redhat.com/@redhat/backstage-plugin-orchestrator-backend-dynamic/-/backstage-plugin-orchestrator-backend-dynamic-1.8.9.tgz"
+    integrity: sha512-V6Css2y21le4SrMj1tpupppjSkvaZcfvfF9sLoknUnFLCCYkKCH21Fpk2BxA1MMRpVXTUjUJ8lTwYAdrrxBEjg==
     pluginConfig:
       orchestrator:
         dataIndexService:
           url: http://sonataflow:8899
   - disabled: false
-    package: "https://npm.registry.redhat.com/@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic/-/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.8.10.tgz"
-    integrity: sha512-jwkwh4sK9jEjbxj6VH/Cr7BAu0nTN2BtLqmeGQWXHwX51U6Vt0hurYi1cHZyD2qPhDRFxZ3rUzWdbKlwNPAvjw==
+    package: "https://npm.registry.redhat.com/@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic/-/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.8.9.tgz"
+    integrity: sha512-VRM/RvqQUemJLBdwm3nYwn2pSTUumZ1YEaHhgh4ELTiuVy2KQcyZCN9cSOCUswjHldmuPyT8dyfGQvSriGNS8Q==
     pluginConfig:
       orchestrator:
         dataIndexService:
           url: http://sonataflow:8899
   - disabled: false
-    package: "https://npm.registry.redhat.com/@redhat/backstage-plugin-orchestrator-form-widgets/-/backstage-plugin-orchestrator-form-widgets-1.8.10.tgz"
-    integrity: sha512-BGnPNkd2JZ8hIrkZ8+/C1RSH1PA7DT8SPqkV1MsrRRONYSJZ/xcVNFb2HWo3BtIjYV3pbASm+vysuBYyxilQog==
+    package: "https://npm.registry.redhat.com/@redhat/backstage-plugin-orchestrator-form-widgets/-/backstage-plugin-orchestrator-form-widgets-1.8.9.tgz"
+    integrity: sha512-fWlawBQUenXQXBUPe04mrIFPhNE05f1aVRJXXFS0FT0doo8X4vijmEeZf4Qm3b1Owgup8E6HHKQr3a94lBrNew==
     pluginConfig:
       dynamicPlugins:
         frontend:


### PR DESCRIPTION
…193)"

This reverts commit 64df5e1b48c749c65461096f469441b8489d3a27.

There will be another orchestrator plugin release which will most likely be 1.8.11 and that one should be used instead.

<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
<!--
Please explain the changes you made here.
-->

## Which issue(s) does this PR fix or relate to

- Fixes #_issue_number_

## PR acceptance criteria

- [ ] Tests updated and passing
- [ ] Documentation updated
- [ ] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

