### PR TITLE
fix(docs): replace `compose restart rhdh` with stop + start

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ After modifying the plugins configuration, for example after configuring plugins
 ```sh
 # Reinstall plugins and restart RHDH
 podman compose run install-dynamic-plugins  # or: docker compose run install-dynamic-plugins
-podman compose restart rhdh                  # or: docker compose restart rhdh
+podman compose stop rhdh                    # or: docker compose stop rhdh
+podman compose start rhdh                   # or: docker compose start rhdh
 ```
 
 ### Quick restart (No Plugin changes)
@@ -59,7 +60,8 @@ For configuration-only changes:
 
 ```sh
 # Just restart RHDH (if plugins haven't changed)
-podman compose restart rhdh  # or: docker compose restart rhdh
+podman compose stop rhdh   # or: docker compose stop rhdh
+podman compose start rhdh  # or: docker compose start rhdh
 ```
 
 ### Clean up

--- a/docs/rhdh-local-guide/configuration.md
+++ b/docs/rhdh-local-guide/configuration.md
@@ -65,19 +65,23 @@ After making configuration changes:
 === "Podman"
     ```bash
     # For app-config changes
-    podman compose restart rhdh
+    podman compose stop rhdh
+    podman compose start rhdh
 
     # For plugin changes
     podman compose run install-dynamic-plugins
-    podman compose restart rhdh
+    podman compose stop rhdh
+    podman compose start rhdh
     ```
 
 === "Docker"
     ```bash
     # For app-config changes
-    docker compose restart rhdh
+    docker compose stop rhdh
+    docker compose start rhdh
 
     # For plugin changes
     docker compose run install-dynamic-plugins
-    docker compose restart rhdh
+    docker compose stop rhdh
+    docker compose start rhdh
     ```

--- a/docs/rhdh-local-guide/dynamic-plugins-management.md
+++ b/docs/rhdh-local-guide/dynamic-plugins-management.md
@@ -25,14 +25,16 @@ After making plugin changes through the UI, restart your local instance with the
     ```bash
     # Reinstall plugins and restart RHDH
     podman compose run install-dynamic-plugins
-    podman compose restart rhdh
+    podman compose stop rhdh
+    podman compose start rhdh
     ```
 
 === "Docker"
     ```bash
     # Reinstall plugins and restart RHDH
     docker compose run install-dynamic-plugins
-    docker compose restart rhdh
+    docker compose stop rhdh
+    docker compose start rhdh
     ```
 
 This process typically may take a few minutes. You can monitor the startup progress in the container logs:
@@ -209,7 +211,8 @@ podman run --rm -it \
 
     # Reinstall plugins without clearing other data
     podman compose run install-dynamic-plugins
-    podman compose restart rhdh
+    podman compose stop rhdh
+    podman compose start rhdh
     ```
 
 === "Docker"
@@ -220,7 +223,8 @@ podman run --rm -it \
 
     # Reinstall plugins without clearing other data
     docker compose run install-dynamic-plugins
-    docker compose restart rhdh
+    docker compose stop rhdh
+    docker compose start rhdh
     ```
 
 ## Applying Plugin Changes
@@ -233,14 +237,16 @@ After modifying the plugin configuration, for example after configuring plugins 
     ```bash
     # Reinstall plugins and restart RHDH
     podman compose run install-dynamic-plugins
-    podman compose restart rhdh
+    podman compose stop rhdh
+    podman compose start rhdh
     ```
 
 === "Docker"
     ```bash
     # Reinstall plugins and restart RHDH
     docker compose run install-dynamic-plugins
-    docker compose restart rhdh
+    docker compose stop rhdh
+    docker compose start rhdh
     ```
 
 ### Quick Restart (No Plugin Changes)
@@ -250,11 +256,13 @@ For configuration-only changes:
 === "Podman"
     ```bash
     # Just restart RHDH (if plugins haven't changed)
-    podman compose restart rhdh
+    podman compose stop rhdh
+    podman compose start rhdh
     ```
 
 === "Docker"
     ```bash
     # Just restart RHDH (if plugins haven't changed)
-    docker compose restart rhdh
+    docker compose stop rhdh
+    docker compose start rhdh
     ```

--- a/docs/rhdh-local-guide/loading-content.md
+++ b/docs/rhdh-local-guide/loading-content.md
@@ -37,13 +37,15 @@ After modifying `app-config.local.yaml`:
 === "Podman"
     ```bash
     # Restart RHDH to load new configuration
-    podman compose restart rhdh
+    podman compose stop rhdh
+    podman compose start rhdh
     ```
 
 === "Docker"
     ```bash
     # Restart RHDH to load new configuration
-    docker compose restart rhdh
+    docker compose stop rhdh
+    docker compose start rhdh
     ```
 
 ## Troubleshooting

--- a/docs/rhdh-local-guide/operating-rhdh-local.md
+++ b/docs/rhdh-local-guide/operating-rhdh-local.md
@@ -149,12 +149,14 @@ After modifying configuration files, restart to apply changes:
 
 === "Podman"
     ```bash
-    podman compose restart rhdh
+    podman compose stop rhdh
+    podman compose start rhdh
     ```
 
 === "Docker"
     ```bash
-    docker compose restart rhdh
+    docker compose stop rhdh
+    docker compose start rhdh
     ```
 
 **For plugin changes** (`configs/dynamic-plugins/dynamic-plugins.override.yaml`):
@@ -165,7 +167,8 @@ After modifying configuration files, restart to apply changes:
     podman compose run install-dynamic-plugins
 
     # Restart RHDH service
-    podman compose restart rhdh
+    podman compose stop rhdh
+    podman compose start rhdh
     ```
 
 === "Docker"
@@ -174,19 +177,22 @@ After modifying configuration files, restart to apply changes:
     docker compose run install-dynamic-plugins
 
     # Restart RHDH service
-    docker compose restart rhdh
+    docker compose stop rhdh
+    docker compose start rhdh
     ```
 
 **For catalog entities** (`configs/catalog-entities/*.yaml`):
 
 === "Podman"
     ```bash
-    podman compose restart rhdh
+    podman compose stop rhdh
+    podman compose start rhdh
     ```
 
 === "Docker"
     ```bash
-    docker compose restart rhdh
+    docker compose stop rhdh
+    docker compose start rhdh
     ```
 
 ### Validating Configuration
@@ -436,7 +442,7 @@ This removes:
 |-----------|--------|--------|
 | Start | `podman compose up -d` | `docker compose up -d` |
 | Stop | `podman compose down` | `docker compose down` |
-| Restart RHDH | `podman compose restart rhdh` | `docker compose restart rhdh` |
+| Restart RHDH | `podman compose stop rhdh`<br>`podman compose start rhdh` | `docker compose stop rhdh`<br>`docker compose start rhdh` |
 | Logs | `podman compose logs -f` | `docker compose logs -f` |
 | Status | `podman compose ps` | `docker compose ps` |
 | Clean up | `podman compose down -v --rmi all` | `docker compose down -v --rmi all` |

--- a/docs/rhdh-local-guide/plugins-guide.md
+++ b/docs/rhdh-local-guide/plugins-guide.md
@@ -66,13 +66,15 @@ You can use RHDH-local with a debugger to debug your backend plugins in VSCode. 
 === "Podman"
     ```sh
     # in rhdh-local directory
-    podman compose restart rhdh
+    podman compose stop rhdh
+    podman compose start rhdh
     ```
 
 === "Docker"
     ```sh
     # in rhdh-local directory
-    docker compose restart rhdh
+    docker compose stop rhdh
+    docker compose start rhdh
     ```
 
 7. Configure VSCode debugger to attach to the `rhdh` container.


### PR DESCRIPTION
## Description

As reported in [1], `podman compose restart` may fail with a `container state improper` error when using the podman-compose provider. For better compatibility, we are instructing to use stop + start instead.

[1] https://redhat.atlassian.net/browse/RHDHBUGS-2747?focusedCommentId=14969895

## Which issue(s) does this PR fix or relate to

https://redhat.atlassian.net/browse/RHDHBUGS-2747?focusedCommentId=14969895

## PR acceptance criteria

- [ ] Tests updated and passing
- [x] Documentation updated
- [x] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

## How to test changes / Special notes to the reviewer
