### PR TITLE
[chore] Only override RHDH and catalog images in nightly checks

### DIFF
--- a/.github/actions/rhdh-local-compose-test/action.yaml
+++ b/.github/actions/rhdh-local-compose-test/action.yaml
@@ -1,6 +1,6 @@
 name: "Test Composite Action"
-description: "Sets RHDH_TAG and RHDH_IMAGE based on the branch name for
-  container image selection for testing purposes"
+description: "Sets RHDH_TAG based on the branch name. Optionally overrides
+  RHDH_IMAGE and CATALOG_INDEX_IMAGE for container image selection (nightly only)."
 
 inputs:
   git_ref:
@@ -48,19 +48,26 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # Set RHDH_TAG and RHDH_IMAGE based on the branch name for container image selection
+    # Set RHDH_TAG and optionally RHDH_IMAGE/CATALOG_INDEX_IMAGE based on the branch name for container image selection
     - name: Set RHDH tag, image and catalog index
       shell: bash
       env:
         INPUT_TAG: ${{ inputs.rhdh_tag_override }}
         BRANCH: ${{ inputs.git_ref }}
+        OVERRIDE_IMAGES: ${{ inputs.override_images }}
       run: |
-        if [ -n "$INPUT_TAG" ]; then TAG="$INPUT_TAG" 
+        if [ -n "$INPUT_TAG" ]; then TAG="$INPUT_TAG"
         elif [ "$BRANCH" = "main" ]; then TAG="next"
         elif [[ "$BRANCH" =~ ^release-[0-9]+\.[0-9]+$ ]]; then TAG="next-${BRANCH#release-}"
         else TAG="next"; fi
 
         echo "RHDH_TAG=$TAG" >> "$GITHUB_ENV"
+
+        if [ "$OVERRIDE_IMAGES" != "true" ]; then
+          echo "override_images is not set; skipping RHDH_IMAGE and CATALOG_INDEX_IMAGE overrides"
+          return 0
+        fi
+
         echo "RHDH_IMAGE=quay.io/rhdh-community/rhdh:$TAG" >> "$GITHUB_ENV"
 
         # Extract CATALOG_INDEX_IMAGE from default.env if it exists, and set as environment variable for use in tests (e.g. for pull-through cache testing)

--- a/.github/actions/rhdh-local-compose-test/action.yaml
+++ b/.github/actions/rhdh-local-compose-test/action.yaml
@@ -32,6 +32,10 @@ inputs:
     description: If set, override the RHDH tag with the value of this input
     required: false
     default: ""
+  override_images:
+    description: "If 'true', override RHDH_IMAGE and CATALOG_INDEX_IMAGE in .env based on the resolved tag. Only nightly checks should do this."
+    required: false
+    default: "false"
   actions_runner_debug:
     description: Adding actions_runner_debug variable value
     required: false
@@ -152,9 +156,14 @@ runs:
 
     - name: Create .env file to override defaults
       shell: bash
+      env:
+        OVERRIDE_IMAGES: ${{ inputs.override_images }}
       run: |
-        echo "CATALOG_INDEX_IMAGE=${{ env.CATALOG_INDEX_IMAGE }}" > .env
-        echo "RHDH_IMAGE=${{ env.RHDH_IMAGE }}" >> .env
+        touch .env
+        if [ "$OVERRIDE_IMAGES" = "true" ]; then
+          echo "CATALOG_INDEX_IMAGE=${{ env.CATALOG_INDEX_IMAGE }}" >> .env
+          echo "RHDH_IMAGE=${{ env.RHDH_IMAGE }}" >> .env
+        fi
         cat .env
 
     - name: Compose config

--- a/.github/actions/rhdh-local-compose-test/action.yaml
+++ b/.github/actions/rhdh-local-compose-test/action.yaml
@@ -56,21 +56,19 @@ runs:
         BRANCH: ${{ inputs.git_ref }}
         OVERRIDE_IMAGES: ${{ inputs.override_images }}
       run: |
+        if [ "$OVERRIDE_IMAGES" != "true" ]; then
+          echo "override_images is not set; skipping RHDH_IMAGE and CATALOG_INDEX_IMAGE overrides"
+          exit 0
+        fi
+
         if [ -n "$INPUT_TAG" ]; then TAG="$INPUT_TAG"
         elif [ "$BRANCH" = "main" ]; then TAG="next"
         elif [[ "$BRANCH" =~ ^release-[0-9]+\.[0-9]+$ ]]; then TAG="next-${BRANCH#release-}"
         else TAG="next"; fi
 
         echo "RHDH_TAG=$TAG" >> "$GITHUB_ENV"
-
-        if [ "$OVERRIDE_IMAGES" != "true" ]; then
-          echo "override_images is not set; skipping RHDH_IMAGE and CATALOG_INDEX_IMAGE overrides"
-          return 0
-        fi
-
         echo "RHDH_IMAGE=quay.io/rhdh-community/rhdh:$TAG" >> "$GITHUB_ENV"
 
-        # Extract CATALOG_INDEX_IMAGE from default.env if it exists, and set as environment variable for use in tests (e.g. for pull-through cache testing)
         if [ "$BRANCH" = "main" ]; then
           CATALOG_TAG="next"
           CATALOG_IMAGE="quay.io/rhdh/plugin-catalog-index:$CATALOG_TAG"

--- a/.github/actions/rhdh-local-compose-test/action.yaml
+++ b/.github/actions/rhdh-local-compose-test/action.yaml
@@ -155,15 +155,11 @@ runs:
       run: $TOOL info
 
     - name: Create .env file to override defaults
+      if: ${{ inputs.override_images == 'true' }}
       shell: bash
-      env:
-        OVERRIDE_IMAGES: ${{ inputs.override_images }}
       run: |
-        touch .env
-        if [ "$OVERRIDE_IMAGES" = "true" ]; then
-          echo "CATALOG_INDEX_IMAGE=${{ env.CATALOG_INDEX_IMAGE }}" >> .env
-          echo "RHDH_IMAGE=${{ env.RHDH_IMAGE }}" >> .env
-        fi
+        echo "CATALOG_INDEX_IMAGE=${{ env.CATALOG_INDEX_IMAGE }}" > .env
+        echo "RHDH_IMAGE=${{ env.RHDH_IMAGE }}" >> .env
         cat .env
 
     - name: Compose config

--- a/.github/actions/rhdh-local-compose-test/action.yaml
+++ b/.github/actions/rhdh-local-compose-test/action.yaml
@@ -50,17 +50,12 @@ runs:
   steps:
     # Set RHDH_TAG and optionally RHDH_IMAGE/CATALOG_INDEX_IMAGE based on the branch name for container image selection
     - name: Set RHDH tag, image and catalog index
+      if: ${{ inputs.override_images == 'true' }}
       shell: bash
       env:
         INPUT_TAG: ${{ inputs.rhdh_tag_override }}
         BRANCH: ${{ inputs.git_ref }}
-        OVERRIDE_IMAGES: ${{ inputs.override_images }}
       run: |
-        if [ "$OVERRIDE_IMAGES" != "true" ]; then
-          echo "override_images is not set; skipping RHDH_IMAGE and CATALOG_INDEX_IMAGE overrides"
-          exit 0
-        fi
-
         if [ -n "$INPUT_TAG" ]; then TAG="$INPUT_TAG"
         elif [ "$BRANCH" = "main" ]; then TAG="next"
         elif [[ "$BRANCH" =~ ^release-[0-9]+\.[0-9]+$ ]]; then TAG="next-${BRANCH#release-}"

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -93,3 +93,4 @@ jobs:
           compose_cli_args: ${{ matrix.composeConfig.cliArgs }}
           compose_config_name: ${{ matrix.composeConfig.name }}
           user_config_enabled: ${{ matrix.userConfig }}
+          override_images: "true"


### PR DESCRIPTION
## Description

PR checks currently override `RHDH_IMAGE` and `CATALOG_INDEX_IMAGE` in `.env`, but they should use the defaults from `compose.yaml`/`default.env`. Only nightly checks need to override these images with branch-derived `next`/`next-*` tags.

This adds an `override_images` input to the composite action (defaults to `"false"`), and only the nightly workflow passes `override_images: "true"`.

## Which issue(s) does this PR fix or relate to

N/A

## PR acceptance criteria

- [x] Tests updated and passing
- [ ] Documentation updated
- [ ] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

## How to test changes / Special notes to the reviewer

- Verify PR CI checks pass using default images from `compose.yaml`
- Trigger a nightly workflow run and verify it still overrides images with `next`/`next-*` tags