### PR TITLE
fix: RHDH Local won't start

### DIFF
--- a/configs/dynamic-plugins/dynamic-plugins.yaml
+++ b/configs/dynamic-plugins/dynamic-plugins.yaml
@@ -15,7 +15,7 @@ plugins:
 # # TODO: Replace the `./dynamic-plugins/dist/` path with the OCI reference once we switch to that in the dynamic-plugins.default.yaml (DPDY) file in the catalog index image - see https://issues.redhat.com/browse/RHDHPLAN-934 and https://issues.redhat.com/browse/RHDHPLAN-256
   # - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay-backend:{{inherit}}'
   #   disabled: false
-  - package: './dynamic-plugins/dist/backstage-community-plugin-quay'
+  - package: ./dynamic-plugins/dist/backstage-community-plugin-quay
     disabled: false
 
   # Scaffolder Github plugin - used by Dynamic Plugin Software Templates

--- a/configs/dynamic-plugins/dynamic-plugins.yaml
+++ b/configs/dynamic-plugins/dynamic-plugins.yaml
@@ -15,7 +15,7 @@ plugins:
 # # TODO: Replace the `./dynamic-plugins/dist/` path with the OCI reference once we switch to that in the dynamic-plugins.default.yaml (DPDY) file in the catalog index image - see https://issues.redhat.com/browse/RHDHPLAN-934 and https://issues.redhat.com/browse/RHDHPLAN-256
   # - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay-backend:{{inherit}}'
   #   disabled: false
-  - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay:{{inherit}}'
+  - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay-backend:{{inherit}}'
     disabled: false
 
   # Scaffolder Github plugin - used by Dynamic Plugin Software Templates

--- a/configs/dynamic-plugins/dynamic-plugins.yaml
+++ b/configs/dynamic-plugins/dynamic-plugins.yaml
@@ -15,7 +15,7 @@ plugins:
 # # TODO: Replace the `./dynamic-plugins/dist/` path with the OCI reference once we switch to that in the dynamic-plugins.default.yaml (DPDY) file in the catalog index image - see https://issues.redhat.com/browse/RHDHPLAN-934 and https://issues.redhat.com/browse/RHDHPLAN-256
   # - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay-backend:{{inherit}}'
   #   disabled: false
-  - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay-backend:{{inherit}}'
+  - package: './dynamic-plugins/dist/backstage-community-plugin-quay'
     disabled: false
 
   # Scaffolder Github plugin - used by Dynamic Plugin Software Templates


### PR DESCRIPTION
## Description
RHDH Local won't start - the Container rhdh-plugins-installer causes an error and cannot complete successfully. Issue with quay - updated package to backend path, which allows it to install correctly. 

## Which issue(s) does this PR fix or relate to

- Fixes [RHDHBUGS-3156](https://redhat.atlassian.net/browse/RHDHBUGS-3156)

## PR acceptance criteria

- [x] Tests updated and passing
- [x] Documentation updated
- [x] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

## How to test changes / Special notes to the reviewer
Run podman compose up -d and RHDH Local should now start as expected. 
