### PR TITLE
chore: add EXTRA_CATALOG_INDEX_IMAGES env var support [RHIDP-12936]

### DIFF
--- a/default.env
+++ b/default.env
@@ -15,6 +15,12 @@ BASE_URL=http://localhost:7007
 # Requires RHDH 1.9+ to be handled.
 CATALOG_INDEX_IMAGE=quay.io/rhdh/plugin-catalog-index:1.10
 
+# Extra catalog index images (comma-separated).
+# Plugins from these images appear in the Extensions UI but are not installed by default.
+# Supports both plain refs and named refs: name=<image_ref>,<image_ref>
+# Requires RHDH 1.10+ to be handled.
+#EXTRA_CATALOG_INDEX_IMAGES=community=quay.io/rhdh/plugin-catalog-index:1.10
+
 # Path in the install-dynamic-plugins container where the extensions catalog entities should be extracted to, from the catalog index image
 # Requires RHDH 1.9+ to be handled
 CATALOG_ENTITIES_EXTRACT_DIR=/extensions

--- a/docs/rhdh-local-guide/configuration.md
+++ b/docs/rhdh-local-guide/configuration.md
@@ -55,6 +55,8 @@ echo "LOG_LEVEL=debug" >> .env
 Common variables to customize:
 
 - `RHDH_IMAGE`: RHDH container image version
+- `CATALOG_INDEX_IMAGE`: Primary plugin catalog index image
+- `EXTRA_CATALOG_INDEX_IMAGES`: Additional catalog index images (comma-separated). See the [catalog index docs](dynamic-plugins-management.md#extra-catalog-index-images) for details
 - `LOG_LEVEL`: RHDH application log level
 - GitHub authentication variables (see the [GitHub auth guide](github-auth.md))
 

--- a/docs/rhdh-local-guide/dynamic-plugins-management.md
+++ b/docs/rhdh-local-guide/dynamic-plugins-management.md
@@ -96,6 +96,25 @@ The default value of the `CATALOG_INDEX_IMAGE` environment variable is defined i
 CATALOG_INDEX_IMAGE=my-registry.example.com/org/my-rhdh-plugin-catalog-index:1.2-3
 ```
 
+### Extra catalog index images
+
+Starting in 1.10, you can configure additional catalog index images alongside the primary one using the `EXTRA_CATALOG_INDEX_IMAGES` environment variable. Plugins from these extra images appear in the Extensions UI but are not installed by default (they do not contribute `dynamic-plugins.default.yaml` files).
+
+Set `EXTRA_CATALOG_INDEX_IMAGES` in your `.env` file as a comma-separated list of image references. You can optionally prefix each reference with a name for cleaner extraction directory names:
+
+```bash
+# Plain image references (directory names are auto-derived from the image ref)
+EXTRA_CATALOG_INDEX_IMAGES=quay.io/my-org/my-catalog-index:1.0
+
+# Named references (recommended — produces cleaner directory names like /extensions/extra/community/)
+EXTRA_CATALOG_INDEX_IMAGES=community=quay.io/rhdh/plugin-catalog-index:1.10
+
+# Multiple images
+EXTRA_CATALOG_INDEX_IMAGES=community=quay.io/rhdh/plugin-catalog-index:1.10,partner=quay.io/my-org/partner-catalog:2.0
+```
+
+Extra catalog entities are extracted under `<CATALOG_ENTITIES_EXTRACT_DIR>/extra/<name>/`, keeping them separate from the primary catalog index.
+
 ### Configuration Structure
 
 Your override file must start with:


### PR DESCRIPTION
## Description

Adds support for configuring multiple catalog index images in RHDH Local via the new `EXTRA_CATALOG_INDEX_IMAGES` env var (introduced in [RHIDP-12933](https://redhat.atlassian.net/browse/RHIDP-12933)).

## Which issue(s) does this PR fix or relate to

- Fixes https://redhat.atlassian.net/browse/RHIDP-12936

## PR acceptance criteria

- [x] Tests updated and passing
- [x] Documentation updated
- [x] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

## How to test changes / Special notes to the reviewer

1. Uncomment `EXTRA_CATALOG_INDEX_IMAGES` in `default.env` (or set it in `.env`)
2. Run `[docker|podman] compose up`
3. Verify the install-dynamic-plugins container extracts the extra catalog index under `/extensions/extra/community/`
4. Verify the extra plugins appear in the Extensions UI