### PR TITLE
chore: Manual backport for 1.10 - dep backend auth keys

### DIFF
--- a/configs/app-config/app-config.yaml
+++ b/configs/app-config/app-config.yaml
@@ -153,8 +153,11 @@ backend:
     connection: ':memory:'
 
   auth:
-    keys:
-      - secret: "development"
+    externalAccess:
+      - type: static
+        options:
+          token: "${RHDH_STATIC_TOKEN}"
+          subject: "local-dev-user"
 
 # You can use local files from catalog-entities directory to load entities into the catalog
 catalog:

--- a/default.env
+++ b/default.env
@@ -25,6 +25,9 @@ CATALOG_INDEX_IMAGE=quay.io/rhdh/plugin-catalog-index:1.10
 # Requires RHDH 1.9+ to be handled
 CATALOG_ENTITIES_EXTRACT_DIR=/extensions
 
+# Static token for static auth provider (if enabled in app-config.yaml)
+RHDH_STATIC_TOKEN=development
+
 # GitHub auth (you need to uncomment github auth section in configs/app-config.local.yaml to enable this)
 #AUTH_GITHUB_CLIENT_ID=
 #AUTH_GITHUB_CLIENT_SECRET=


### PR DESCRIPTION
## Description
Removing deprecated backend auth keys - replacing with static token

## Which issue(s) does this PR fix or relate to

- https://redhat.atlassian.net/browse/RHDHBUGS-2686

## PR acceptance criteria

- [x] Tests updated and passing
- [x] Documentation updated
- [x] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

