### PR TITLE
fix: Manual backport of Night tests to 1.8

### DIFF
--- a/.github/actions/rhdh-local-compose-test/action.yaml
+++ b/.github/actions/rhdh-local-compose-test/action.yaml
@@ -1,0 +1,283 @@
+name: "Test Composite Action"
+description: "Sets RHDH_TAG and RHDH_IMAGE based on the branch name for
+  container image selection for testing purposes"
+
+inputs:
+  git_ref:
+    description: Branch to checkout (e.g. main, release-1.0, release-1.1)
+    required: true
+  container_tool:
+    description: Container tool to use (e.g. docker, podman)
+    required: true
+  compose_cli_args:
+    description: Args for `docker compose` or `podman compose` command
+    required: false
+    default: ""
+  compose_config_name:
+    description: Compose config name to use (e.g. default, dynamic-plugins-root)
+    required: true
+  user_config_enabled:
+    description: "\"true\" or \"false\" to enable user-specific configuration"
+    required: true
+  docker_compose_version:
+    description: Version of docker-compose to install
+    required: true
+  podman_image:
+    description: Image to use for Podman container
+    required: true
+  corporate_proxy_image:
+    description: Image to use for Corporate Proxy container
+    required: true
+  rhdh_tag_override:
+    description: If set, override the RHDH tag with the value of this input
+    required: false
+    default: ""
+  actions_runner_debug:
+    description: Adding actions_runner_debug variable value
+    required: false
+    default: "false"
+  log_level:
+    description: Log level to use
+    required: false
+    default: "info"
+
+runs:
+  using: "composite"
+  steps:
+    # Set RHDH_TAG and RHDH_IMAGE based on the branch name for container image selection
+    - name: Set RHDH tag, image and catalog index
+      shell: bash
+      env:
+        INPUT_TAG: ${{ inputs.rhdh_tag_override }}
+        BRANCH: ${{ inputs.git_ref }}
+      run: |
+        if [ -n "$INPUT_TAG" ]; then TAG="$INPUT_TAG" 
+        elif [ "$BRANCH" = "main" ]; then TAG="next"
+        elif [[ "$BRANCH" =~ ^release-[0-9]+\.[0-9]+$ ]]; then TAG="next-${BRANCH#release-}"
+        else TAG="next"; fi
+
+        echo "RHDH_TAG=$TAG" >> "$GITHUB_ENV"
+        echo "RHDH_IMAGE=quay.io/rhdh-community/rhdh:$TAG" >> "$GITHUB_ENV"
+
+        # Extract CATALOG_INDEX_IMAGE from default.env if it exists, and set as environment variable for use in tests (e.g. for pull-through cache testing)
+        if [ "$BRANCH" = "main" ]; then
+          CATALOG_TAG="next"
+          CATALOG_IMAGE="quay.io/rhdh/plugin-catalog-index:$CATALOG_TAG"
+          echo "CATALOG_INDEX_IMAGE=$CATALOG_IMAGE" >> "$GITHUB_ENV"
+          echo "Set CATALOG_INDEX_IMAGE based on branch name: $CATALOG_IMAGE"
+        elif [ -f "default.env" ] && grep -q "^CATALOG_INDEX_IMAGE=" default.env; then
+          CATALOG_IMAGE=$(grep "^CATALOG_INDEX_IMAGE=" default.env | cut -d '=' -f2-)
+          echo "CATALOG_INDEX_IMAGE=$CATALOG_IMAGE" >> "$GITHUB_ENV"
+          echo "Set CATALOG_INDEX_IMAGE from default.env: $CATALOG_IMAGE"
+        else
+          echo "CATALOG_INDEX_IMAGE not found in default.env, skipping"
+        fi
+
+    - name: Remove Conflicting Packages
+      shell: bash
+      run: |
+        # Remove any previous installations of Podman and Docker
+        for pkg in docker.io \
+            docker-doc \
+            docker-compose \
+            docker-compose-v2 \
+            podman-docker \
+            containerd \
+            crun \
+            runc \
+            buildah \
+          ; do
+          sudo apt-get remove --purge -y $pkg || true
+        done
+
+    - name: Update Docker version
+      shell: bash
+      env:
+        DOCKER_COMPOSE_VERSION: v5.0.1
+      run: |
+        # Add Docker's official GPG key:
+        sudo apt-get update
+        sudo apt-get install -y ca-certificates curl
+        sudo install -m 0755 -d /etc/apt/keyrings
+        sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+        sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+        # Add the repository to Apt sources:
+        echo \
+          "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+          $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
+          sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+        sudo apt-get update
+        sudo apt-get install -y docker-ce \
+          docker-ce-cli \
+          containerd.io \
+          docker-buildx-plugin
+
+        # Install standalone docker-compose for consistent version across docker/podman tests
+        echo "Installing docker-compose $DOCKER_COMPOSE_VERSION..."
+        sudo curl -fsSL "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-$(uname -m)" \
+          -o /usr/local/bin/docker-compose
+        sudo chmod +x /usr/local/bin/docker-compose
+        # Also install as Docker CLI plugin
+        sudo mkdir -p /usr/local/lib/docker/cli-plugins
+        sudo ln -sf /usr/local/bin/docker-compose /usr/local/lib/docker/cli-plugins/docker-compose
+
+    - name: Setup Podman container environment
+      id: setup-podman
+      if: ${{ inputs.container_tool == 'podman' }}
+      uses: rm3l/setup-containerized-podman@7e2e9a2ddc2da87cbe754c0ed8975b7368388f56 # v2.0.0
+      with:
+        podman-image: quay.io/podman/stable:v5
+        compose-provider: docker-compose
+        docker-compose-version: v5.0.1
+        env: |
+          CORPORATE_PROXY_IMAGE=docker.io/ubuntu/squid:latest
+
+    - name: Display container engine version
+      shell: bash
+      env:
+        TOOL: ${{ inputs.container_tool }}
+      run: |
+        echo "*** $TOOL version ***"
+        $TOOL version
+        echo
+        echo "*** $TOOL compose version ***"
+        $TOOL compose version
+
+    - name: ${{ inputs.container_tool }} info
+      shell: bash
+      env:
+        TOOL: ${{ inputs.container_tool }}
+      run: $TOOL info
+
+    - name: Create .env file to override defaults
+      shell: bash
+      run: |
+        echo "CATALOG_INDEX_IMAGE=${{ env.CATALOG_INDEX_IMAGE }}" > .env
+        echo "RHDH_IMAGE=${{ env.RHDH_IMAGE }}" >> .env
+        cat .env
+
+    - name: Compose config
+      shell: bash
+      env:
+        TOOL: ${{ inputs.container_tool }}
+        CLI_ARGS: ${{ inputs.compose_cli_args }}
+        CATALOG_INDEX_IMAGE: ${{ env.CATALOG_INDEX_IMAGE }}
+      run: $TOOL compose $CLI_ARGS config
+
+    - name: Add user-specific configuration
+      if: ${{ inputs.user_config_enabled == 'true' }}
+      shell: bash
+      env:
+        # https://docs.github.com/en/actions/how-tos/monitor-workflows/enable-debug-logging#enabling-runner-diagnostic-logging
+        LOG_LEVEL: ${{ env.ACTIONS_RUNNER_DEBUG == 'true' && 'debug' || 'info' }}
+      run: |
+        # Custom .env file
+        cat <<EOF >> .env
+        LOG_LEVEL=$LOG_LEVEL
+        ROARR_LOG=true
+        NODE_DEBUG=fetch
+
+        GITHUB_APP_APP_ID=123456
+        GITHUB_APP_CLIENT_ID=MY_GITHUB_APP_CLIENT_ID
+        GITHUB_APP_CLIENT_SECRET=MY_GITHUB_APP_CLIENT_SECRET
+        GITHUB_APP_WEBHOOK_SECRET=MY_GITHUB_APP_WEBHOOK_SECRET
+        GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\nxxx\n-----END RSA PRIVATE KEY-----" # notsecret
+
+        EOF
+
+        # Custom dynamic-plugins.override.yaml
+        cat <<EOF > configs/dynamic-plugins/dynamic-plugins.override.yaml
+        includes: [dynamic-plugins.default.yaml]
+        plugins:
+        - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic
+          disabled: false
+        - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import
+          disabled: false
+        EOF
+
+        # Custom extra files
+        cp -vr configs/extra-files/github-app-credentials.example.yaml configs/extra-files/github-app-credentials.yaml
+
+        # Custom app-config.local.yaml
+        cp -vr configs/app-config/app-config.local.example.yaml configs/app-config/app-config.local.yaml
+
+        # Custom users.override.yaml
+        cp configs/catalog-entities/users.override.example.yaml configs/catalog-entities/users.override.yaml
+
+        # Custom components.override.yaml
+        cp configs/catalog-entities/components.override.example.yaml configs/catalog-entities/components.override.yaml
+
+    - name: Create dynamic plugins directory
+      if: ${{ inputs.compose_config_name == 'dynamic-plugins-root' }}
+      shell: bash
+      run: |
+        mkdir -p dynamic-plugins-root
+
+    - name: Start app
+      shell: bash
+      env:
+        TOOL: ${{ inputs.container_tool }}
+        CLI_ARGS: ${{ inputs.compose_cli_args }}
+        CATALOG_INDEX_IMAGE: ${{ env.CATALOG_INDEX_IMAGE }}
+      run: |
+        $TOOL compose $CLI_ARGS up --detach --quiet-pull
+        $TOOL compose $CLI_ARGS ps
+
+    - name: Wait for HTTP 200 response from homepage
+      shell: bash
+      run: |
+        max=50
+        i=0
+        echo "Waiting for localhost to respond with status code 200..."
+        until curl -i --head --fail http://localhost:7007; do
+          i=$((i+1))
+          if [ "$i" -ge "$max" ]; then
+            echo "[$(date)] Max retries reached. Exiting. Take a look at the logs in the step below."
+            exit 1
+          fi
+          echo "($i/$max) [$(date)] Waiting for http://localhost:7007 to return HTTP 200..."
+          sleep 10
+        done
+        echo "[$(date)] RHDH is ready"
+        curl -i --insecure http://localhost:7007
+
+    - name: curl from RHDH Container (for troubleshooting)
+      if: failure()
+      shell: bash
+      env:
+        TOOL: ${{ inputs.container_tool }}
+        CLI_ARGS: ${{ inputs.compose_cli_args }}
+      run: |
+        $TOOL exec rhdh curl -i --head --fail http://localhost:7007
+
+    - name: Compose logs
+      if: always()
+      shell: bash
+      env:
+        TOOL: ${{ inputs.container_tool }}
+        CLI_ARGS: ${{ inputs.compose_cli_args }}
+      run: |
+        for svc in $($TOOL compose $CLI_ARGS config --services | sort); do
+          echo "*** $svc ***"
+          $TOOL compose $CLI_ARGS logs --timestamps "$svc" || true
+          echo "************"
+          echo
+        done
+
+    - name: Tear down
+      if: always()
+      shell: bash
+      env:
+        TOOL: ${{ inputs.container_tool }}
+        CLI_ARGS: ${{ inputs.compose_cli_args }}
+      run: |
+        $TOOL compose $CLI_ARGS ps || true
+        $TOOL compose $CLI_ARGS down --volumes || true
+
+    - name: Cleanup Podman container environment
+      if: ${{ always() && inputs.container_tool == 'podman' }}
+      shell: bash
+      run: |
+        docker container stop ${{ steps.setup-podman.outputs.container-name }} || true
+        docker container rm ${{ steps.setup-podman.outputs.container-name }} || true

--- a/.github/actions/rhdh-local-compose-test/action.yaml
+++ b/.github/actions/rhdh-local-compose-test/action.yaml
@@ -1,6 +1,6 @@
 name: "Test Composite Action"
-description: "Sets RHDH_TAG and RHDH_IMAGE based on the branch name for
-  container image selection for testing purposes"
+description: "Sets RHDH_TAG based on the branch name. Optionally overrides
+  RHDH_IMAGE and CATALOG_INDEX_IMAGE for container image selection (nightly only)."
 
 inputs:
   git_ref:
@@ -32,6 +32,10 @@ inputs:
     description: If set, override the RHDH tag with the value of this input
     required: false
     default: ""
+  override_images:
+    description: "If 'true', override RHDH_IMAGE and CATALOG_INDEX_IMAGE in .env based on the resolved tag. Only nightly checks should do this."
+    required: false
+    default: "false"
   actions_runner_debug:
     description: Adding actions_runner_debug variable value
     required: false
@@ -44,14 +48,15 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # Set RHDH_TAG and RHDH_IMAGE based on the branch name for container image selection
+    # Set RHDH_TAG and optionally RHDH_IMAGE/CATALOG_INDEX_IMAGE based on the branch name for container image selection
     - name: Set RHDH tag, image and catalog index
+      if: ${{ inputs.override_images == 'true' }}
       shell: bash
       env:
         INPUT_TAG: ${{ inputs.rhdh_tag_override }}
         BRANCH: ${{ inputs.git_ref }}
       run: |
-        if [ -n "$INPUT_TAG" ]; then TAG="$INPUT_TAG" 
+        if [ -n "$INPUT_TAG" ]; then TAG="$INPUT_TAG"
         elif [ "$BRANCH" = "main" ]; then TAG="next"
         elif [[ "$BRANCH" =~ ^release-[0-9]+\.[0-9]+$ ]]; then TAG="next-${BRANCH#release-}"
         else TAG="next"; fi
@@ -59,7 +64,6 @@ runs:
         echo "RHDH_TAG=$TAG" >> "$GITHUB_ENV"
         echo "RHDH_IMAGE=quay.io/rhdh-community/rhdh:$TAG" >> "$GITHUB_ENV"
 
-        # Extract CATALOG_INDEX_IMAGE from default.env if it exists, and set as environment variable for use in tests (e.g. for pull-through cache testing)
         if [ "$BRANCH" = "main" ]; then
           CATALOG_TAG="next"
           CATALOG_IMAGE="quay.io/rhdh/plugin-catalog-index:$CATALOG_TAG"
@@ -151,6 +155,7 @@ runs:
       run: $TOOL info
 
     - name: Create .env file to override defaults
+      if: ${{ inputs.override_images == 'true' }}
       shell: bash
       run: |
         echo "CATALOG_INDEX_IMAGE=${{ env.CATALOG_INDEX_IMAGE }}" > .env

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,95 @@
+name: Nightly tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "34 23 * * *"
+
+concurrency:
+  group: ${{ github.workflow}}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Lint
+        run: |
+          npx --yes dclint .
+
+  # Finds new release branches at runtime; no workflow edit when new releases are created
+  discover-branches:
+    runs-on: ubuntu-latest
+    outputs:
+      branches: ${{ steps.set-branches.outputs.branches }}
+    steps:
+      - uses: actions/github-script@v8
+        id: set-branches
+        with:
+          script: |
+            const branches = await github.paginate(github.rest.repos.listBranches, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            // Keep main and the latest 3 release branches (e.g. release-1.2, release-1.1, release-1.0) - to cover EOL branches and period between FF and GA of new releases
+            const topReleaseBranches = branches
+              .map(b => b.name)
+              .filter(name => /^release-\d+\.\d+$/.test(name))
+              .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }))
+              .slice(0, 3);
+
+            core.setOutput('branches', JSON.stringify(['main', ...topReleaseBranches]));
+  test:
+    needs: discover-branches
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJson(needs.discover-branches.outputs.branches) }}
+        os:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+        tool:
+          - docker
+          - podman
+        userConfig:
+          - "false"
+          - "true"
+        composeConfig:
+          - name: "default"
+            cliArgs: ""
+          - name: "corporate-proxy"
+            cliArgs: "-f compose.yaml -f compose-with-corporate-proxy.yaml"
+          - name: "dynamic-plugins-root"
+            cliArgs: "-f compose.yaml -f compose-dynamic-plugins-root.yaml"
+          - name: "orchestrator-workflow"
+            cliArgs: "-f compose.yaml -f orchestrator/compose.yaml"
+          - name: "developer-lightspeed"
+            cliArgs: "-f compose.yaml -f developer-lightspeed/compose.yaml"
+
+    name: "${{ matrix.branch }} - ${{ matrix.tool }} compose - ${{
+      matrix.composeConfig.name }}${{ matrix.os != 'ubuntu-24.04' && format(' -
+      {0}', matrix.os) || '' }}${{ matrix.userConfig == 'true' && ' - user
+      config' || '' }}"
+    runs-on: ${{ matrix.os }}
+    env:
+      DOCKER_COMPOSE_VERSION: v5.0.1
+      PODMAN_IMAGE: quay.io/podman/stable:v5
+      CORPORATE_PROXY_IMAGE: docker.io/ubuntu/squid:latest
+      ACTIONS_RUNNER_DEBUG: ${{ vars.ACTIONS_RUNNER_DEBUG }}
+
+    steps:
+      # Checkout a ref that contains .github/actions/*. schedule: github.ref_name is always the default branch.
+      # workflow_dispatch: use default_branch (trigger ref may be release-* without the composite on that branch).
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ matrix.branch }}
+          fetch-depth: 1
+      - uses: ./.github/actions/rhdh-local-compose-test
+        with:
+          git_ref: ${{ matrix.branch }}
+          container_tool: ${{ matrix.tool }}
+          compose_cli_args: ${{ matrix.composeConfig.cliArgs }}
+          compose_config_name: ${{ matrix.composeConfig.name }}
+          user_config_enabled: ${{ matrix.userConfig }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -93,3 +93,4 @@ jobs:
           compose_cli_args: ${{ matrix.composeConfig.cliArgs }}
           compose_config_name: ${{ matrix.composeConfig.name }}
           user_config_enabled: ${{ matrix.userConfig }}
+          override_images: "true"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - ubuntu-24.04
         tool:
           - docker
           - podman
@@ -59,87 +61,12 @@ jobs:
       PODMAN_COMPOSE_PROVIDER: "podman-compose"
 
     steps:
-    - uses: actions/checkout@v4
-
-    - name: Install tool
-      if: ${{ matrix.tool == 'podman' }}
-      env:
-        PODMAN_COMPOSE_VERSION: "v1.3.0"
-      run: |
-        pip3 install podman-compose=="${PODMAN_COMPOSE_VERSION}"
-
-    - name: Add user-specific configuration
-      if: ${{ matrix.userConfig == 'true' }}
-      run: |
-        # Custom .env file
-        cat <<EOF > .env
-        LOG_LEVEL=debug
-        ROARR_LOG=true
-        NODE_DEBUG=fetch
-
-        GITHUB_APP_APP_ID=123456
-        GITHUB_APP_CLIENT_ID=MY_GITHUB_APP_CLIENT_ID
-        GITHUB_APP_CLIENT_SECRET=MY_GITHUB_APP_CLIENT_SECRET
-        GITHUB_APP_WEBHOOK_SECRET=MY_GITHUB_APP_WEBHOOK_SECRET
-        GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\nxxx\n-----END RSA PRIVATE KEY-----" # notsecret
-
-        EOF
-
-        # Custom dynamic-plugins.override.yaml
-        cat <<EOF > configs/dynamic-plugins/dynamic-plugins.override.yaml
-        includes: [dynamic-plugins.default.yaml]
-        plugins:
-        - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic
-          disabled: false
-        - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import
-          disabled: false
-        EOF
-
-        # Custom extra files
-        cp -vr configs/extra-files/github-app-credentials.example.yaml configs/extra-files/github-app-credentials.yaml
-
-        # Custom app-config.local.yaml
-        cp -vr configs/app-config/app-config.local.example.yaml configs/app-config/app-config.local.yaml
-
-        # Custom users.override.yaml
-        cp configs/catalog-entities/users.override.example.yaml configs/catalog-entities/users.override.yaml
-
-        # Custom components.override.yaml
-        cp configs/catalog-entities/components.override.example.yaml configs/catalog-entities/components.override.yaml
-
-    - name: Create dynamic plugins directory
-      if: ${{ matrix.composeConfig.name == 'dynamic-plugins-root' }}
-      run: |
-          mkdir -p dynamic-plugins-root
-
-    - name: Start app
-      run: |
-        ${{ matrix.tool }} compose ${{ matrix.composeConfig.cliArgs }} up --detach --quiet-pull
-        ${{ matrix.tool }} compose ${{ matrix.composeConfig.cliArgs }} ps
-
-    - name: Wait for HTTP 200 response from homepage
-      run: |
-        max=30
-        i=0
-        echo "Waiting for localhost to respond with status code 200..."
-        until curl --head --fail http://localhost:7007; do
-          i=$((i+1))
-          if [ "$i" -ge "$max" ]; then
-            echo "Max retries reached. Exiting. Take a look at the logs in the step below."
-            exit 1
-          fi
-          echo "($i/$max)Waiting for http://localhost:7007 to return HTTP 200..."
-          sleep 5
-        done
-        echo "RHDH is ready!"
-        curl -i --insecure http://localhost:7007
-
-    - name: Compose logs
-      if: always()
-      run: ${{ matrix.tool }} compose ${{ matrix.composeConfig.cliArgs }} logs
-
-    - name: Tear down
-      if: always()
-      run: |
-        ${{ matrix.tool }} compose ${{ matrix.composeConfig.cliArgs }} ps || true
-        ${{ matrix.tool }} compose ${{ matrix.composeConfig.cliArgs }} down --volumes || true
+      # Checkout default branch so .github/actions/* exists (release-* push may not include the composite).
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/rhdh-local-compose-test
+        with:
+          git_ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          container_tool: ${{ matrix.tool }}
+          compose_cli_args: ${{ matrix.composeConfig.cliArgs }}
+          compose_config_name: ${{ matrix.composeConfig.name }}
+          user_config_enabled: ${{ matrix.userConfig }}


### PR DESCRIPTION
## Description
Manually backporting nightly tests to 1.8 due to failed cherry-pick

## PR acceptance criteria

- [x] Tests updated and passing
- [x] Documentation updated
- [x] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

