### PR TITLE
fix: Remove lightspeed from nightly tests

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -65,6 +65,8 @@ jobs:
             cliArgs: "-f compose.yaml -f compose-dynamic-plugins-root.yaml"
           - name: "orchestrator-workflow"
             cliArgs: "-f compose.yaml -f orchestrator/compose.yaml"
+          # TODO: Remove this and the exclude rule below when the minimum supported version is 1.10
+          # (with Lightspeed enabled by default)
           - name: "developer-lightspeed"
             cliArgs: "-f compose.yaml -f developer-lightspeed/compose.yaml"
         exclude:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -65,6 +65,14 @@ jobs:
             cliArgs: "-f compose.yaml -f compose-dynamic-plugins-root.yaml"
           - name: "orchestrator-workflow"
             cliArgs: "-f compose.yaml -f orchestrator/compose.yaml"
+          - name: "developer-lightspeed"
+            cliArgs: "-f compose.yaml -f developer-lightspeed/compose.yaml"
+        exclude:
+          # Skip developer-lightspeed on release-1.10 branch
+          - branch: "release-1.10"
+            composeConfig:
+              name: "developer-lightspeed"
+              cliArgs: "-f compose.yaml -f developer-lightspeed/compose.yaml"
 
     name: "${{ matrix.branch }} - ${{ matrix.tool }} compose - ${{
       matrix.composeConfig.name }}${{ matrix.os != 'ubuntu-24.04' && format(' -

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -65,8 +65,6 @@ jobs:
             cliArgs: "-f compose.yaml -f compose-dynamic-plugins-root.yaml"
           - name: "orchestrator-workflow"
             cliArgs: "-f compose.yaml -f orchestrator/compose.yaml"
-          - name: "developer-lightspeed"
-            cliArgs: "-f compose.yaml -f developer-lightspeed/compose.yaml"
 
     name: "${{ matrix.branch }} - ${{ matrix.tool }} compose - ${{
       matrix.composeConfig.name }}${{ matrix.os != 'ubuntu-24.04' && format(' -

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,8 +47,6 @@ jobs:
             cliArgs: "-f compose.yaml -f compose-dynamic-plugins-root.yaml"
           - name: "orchestrator-workflow"
             cliArgs: "-f compose.yaml -f orchestrator/compose.yaml"
-          - name: "developer-lightspeed"
-            cliArgs: "-f compose.yaml -f developer-lightspeed/compose.yaml"
 
     name: "${{ matrix.tool }} compose - ${{ matrix.composeConfig.name }}${{ matrix.os != 'ubuntu-24.04' && format(' - {0}', matrix.os) || '' }}${{ matrix.userConfig == 'true' && ' - user config' || '' }}"
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,16 +15,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
   lint:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
-    - name: Lint
-      # Based on https://github.com/zavoloklom/docker-compose-linter/tree/main?tab=readme-ov-file
-      run: |
-        npx --yes dclint .
+      - uses: actions/checkout@v6
+      - name: Lint
+        # Based on https://github.com/zavoloklom/docker-compose-linter/tree/main?tab=readme-ov-file
+        run: |
+          npx --yes dclint .
 
   test:
     strategy:
@@ -47,6 +46,8 @@ jobs:
             cliArgs: "-f compose.yaml -f compose-dynamic-plugins-root.yaml"
           - name: "orchestrator-workflow"
             cliArgs: "-f compose.yaml -f orchestrator/compose.yaml"
+          - name: "developer-lightspeed"
+            cliArgs: "-f compose.yaml -f developer-lightspeed/compose.yaml"
 
     name: "${{ matrix.tool }} compose - ${{ matrix.composeConfig.name }}${{ matrix.os != 'ubuntu-24.04' && format(' - {0}', matrix.os) || '' }}${{ matrix.userConfig == 'true' && ' - user config' || '' }}"
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Description
Removing lightspeed from nightly tests and pr checks. Tests failing since lightspeed is automatically enabled.

## Which issue(s) does this PR fix or relate to

- Fixes [RHDHBUGS-3178](https://redhat.atlassian.net/browse/RHDHBUGS-3178)

## PR acceptance criteria

- [x] Tests updated and passing
- [x] Documentation updated
- [x] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.
