### PR TITLE
fix(techdocs): use writable workdir for local TechDocs generation

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -38,9 +38,11 @@ services:
     environment:
       NODE_OPTIONS: "--inspect=0.0.0.0:9229 --no-node-snapshot"
     volumes:
-      - ./mkdocs.yaml:/opt/app-root/src/mkdocs.yaml:Z
-      - ./docs:/opt/app-root/src/docs:Z
-      - ./catalog-info.yaml:/opt/app-root/src/catalog-info.yaml:Z
+      # TechDocs source files are bind-mounted read-only and copied to a writable
+      # in-container workdir on startup
+      - ./mkdocs.yaml:/opt/app-root/src/techdocs-source/mkdocs.yaml:ro,z
+      - ./docs:/opt/app-root/src/techdocs-source/docs:ro,z
+      - ./catalog-info.yaml:/opt/app-root/src/techdocs-source/catalog-info.yaml:ro,z
       - ./wait-for-plugins-and-start.sh:/opt/app-root/src/wait-for-plugins-and-start.sh:Z
       - ./configs:/opt/app-root/src/configs:z
       - dynamic-plugins-root:/opt/app-root/src/dynamic-plugins-root

--- a/configs/app-config/app-config.yaml
+++ b/configs/app-config/app-config.yaml
@@ -175,7 +175,7 @@ catalog:
 
   locations:
     - type: file
-      target: /opt/app-root/src/catalog-info.yaml
+      target: /opt/app-root/src/techdocs-workdir/catalog-info.yaml
     - type: file
       target: /opt/app-root/src/configs/catalog-entities/users.yaml
       rules:

--- a/docs/rhdh-local-guide/help-and-contrib.md
+++ b/docs/rhdh-local-guide/help-and-contrib.md
@@ -209,6 +209,21 @@ See [Making Your TechDocs More Appealing](../getting-started-rhdh/making-techdoc
 3. **Preview in RHDH Local** to verify formatting and links work
 4. **Have someone else test** your instructions (when possible)
 
+#### Applying local changes
+
+At container startup, RHDH Local copies `mkdocs.yaml`, `docs/`, and `catalog-info.yaml` from a read-only bind mount into a writable in-container workdir. TechDocs generation updates `mkdocs.yaml` in that workdir, so the running instance does not watch your host files directly.
+
+After editing built-in TechDocs on the host, restart the RHDH container to pick up your changes:
+
+```bash
+podman compose restart rhdh
+# or, if using Docker Compose:
+docker compose restart rhdh
+```
+
+!!! note "Restart required for local preview"
+    Previously, editing `docs/` on the host was reflected in the TechDocs UI after a page reload. With the writable workdir copy, a container restart is required to re-sync source files before you can preview updates in RHDH Local.
+
 #### TechDocs Review Process
 
 Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

--- a/docs/rhdh-local-guide/help-and-contrib.md
+++ b/docs/rhdh-local-guide/help-and-contrib.md
@@ -216,9 +216,8 @@ At container startup, RHDH Local copies `mkdocs.yaml`, `docs/`, and `catalog-inf
 After editing built-in TechDocs on the host, restart the RHDH container to pick up your changes:
 
 ```bash
-podman compose restart rhdh
-# or, if using Docker Compose:
-docker compose restart rhdh
+podman compose stop rhdh   # or: docker compose stop rhdh
+podman compose start rhdh  # or: docker compose start rhdh
 ```
 
 !!! note "Restart required for local preview"

--- a/wait-for-plugins-and-start.sh
+++ b/wait-for-plugins-and-start.sh
@@ -21,6 +21,17 @@ LEGACY_USER_APP_CONFIG="configs/app-config.local.yaml"
 USERS_OVERRIDE="configs/catalog-entities/users.override.yaml"
 
 mkdir -p generated
+
+# Copy TechDocs source files into a writable workdir for in-place mkdocs.yaml updates
+# during TechDocs generation
+TECHDOCS_SOURCE="/opt/app-root/src/techdocs-source"
+TECHDOCS_WORKDIR="/opt/app-root/src/techdocs-workdir"
+if [ -d "$TECHDOCS_SOURCE" ]; then
+  echo "Syncing TechDocs source files to writable workdir"
+  mkdir -p "$TECHDOCS_WORKDIR"
+  cp -a "$TECHDOCS_SOURCE/"* "$TECHDOCS_WORKDIR/"
+fi
+
 cp -f "$DEFAULT_APP_CONFIG" "$PATCHED_APP_CONFIG"
 
 # Wait until the dynamic plugin config is ready

--- a/wait-for-plugins-and-start.sh
+++ b/wait-for-plugins-and-start.sh
@@ -26,7 +26,7 @@ mkdir -p generated
 # during TechDocs generation
 TECHDOCS_SOURCE="/opt/app-root/src/techdocs-source"
 TECHDOCS_WORKDIR="/opt/app-root/src/techdocs-workdir"
-if [ -d "$TECHDOCS_SOURCE" ]; then
+if [[ -d "$TECHDOCS_SOURCE" ]]; then
   echo "Syncing TechDocs source files to writable workdir"
   mkdir -p "$TECHDOCS_WORKDIR"
   cp -a "$TECHDOCS_SOURCE/"* "$TECHDOCS_WORKDIR/"


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

During local generation,  `sanitizeMkdocsYml()` in @backstage/plugin-techdocs-node always rewrites mkdocs.yaml in place before generation. The previous  compose setup bind-mounted those files directly from the host, so the container user could not write them and TechDocs publish either had warnings or failed with EACCES. (more details in https://redhat.atlassian.net/browse/RHDHBUGS-3360?focusedCommentId=17297355)

To fix this, this PR:

   - Mounts TechDocs source files (`mkdocs.yaml`, `docs/`, `catalog-info.yaml`) read-only under `techdocs-source/`                         
   - Copies them into a writable in-container techdocs-workdir on startup                                                             
   - Points the catalog file location at the workdir copy so `backstage.io/techdocs-ref: dir:.` resolves to a writable tree                     

## Which issue(s) does this PR fix or relate to

- Fixes: https://redhat.atlassian.net/browse/RHDHBUGS-3360

## PR acceptance criteria

- [x] Tests updated and passing
- [ ] Documentation updated
- [ ] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

run `podman compose up` and navigate to the RHDH Guide (http://localhost:7007/catalog/default/system/rhdh-local/docs), the docs should be visible as expected without errors/warnings. 