### PR TITLE
fix(nightly): fall back to downstream image when community tag expires

### DIFF
--- a/.github/actions/rhdh-local-compose-test/action.yaml
+++ b/.github/actions/rhdh-local-compose-test/action.yaml
@@ -62,7 +62,17 @@ runs:
         else TAG="next"; fi
 
         echo "RHDH_TAG=$TAG" >> "$GITHUB_ENV"
-        echo "RHDH_IMAGE=quay.io/rhdh-community/rhdh:$TAG" >> "$GITHUB_ENV"
+
+        RHDH_IMAGE="quay.io/rhdh-community/rhdh:$TAG"
+        if ! skopeo list-tags "docker://quay.io/rhdh-community/rhdh" | grep -q "\"$TAG\""; then
+          if [[ "$TAG" == next-* ]]; then
+            RHDH_IMAGE="quay.io/rhdh/rhdh-hub-rhel9:${TAG#next-}"
+          else
+            RHDH_IMAGE="quay.io/rhdh/rhdh-hub-rhel9:$TAG"
+          fi
+          echo "::warning::Community image tag '$TAG' not found or expired. Falling back to $RHDH_IMAGE"
+        fi
+        echo "RHDH_IMAGE=$RHDH_IMAGE" >> "$GITHUB_ENV"
 
         if [ "$BRANCH" = "main" ]; then
           CATALOG_TAG="next"


### PR DESCRIPTION
## Description

Community image tags (`next-1.y`, `next`) on `quay.io/rhdh-community/rhdh` can expire, causing nightly tests to fail.

This adds a fallback mechanism: before using the community image, we verify the tag exists and fall back if needed to the downstream image `quay.io/rhdh/rhdh-hub-rhel9`, which does not expire:
- `next-X.Y` → `quay.io/rhdh/rhdh-hub-rhel9:X.Y`
- `next` → `quay.io/rhdh/rhdh-hub-rhel9:next`

## Which issue(s) does this PR fix or relate to

https://github.com/redhat-developer/rhdh-local/actions/runs/27797092690/job/82259143916#step:3:664

## PR acceptance criteria

- [x] Tests updated and passing
- [ ] Documentation updated
- [ ] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

## How to test changes / Special notes to the reviewer