### PR TITLE
ci(nightly): reduce ARM test matrix to representative subset

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -70,6 +70,25 @@ jobs:
           - name: "developer-lightspeed"
             cliArgs: "-f compose.yaml -f developer-lightspeed/compose.yaml"
         exclude:
+          # ARM tests verify architecture compatibility, not functional differences
+          # that vary by compose config or container tool. A representative subset
+          # (docker + default/orchestrator + no user config) is sufficient per branch.
+          - os: ubuntu-24.04-arm
+            tool: podman
+          - os: ubuntu-24.04-arm
+            userConfig: "true"
+          - os: ubuntu-24.04-arm
+            composeConfig:
+              name: "corporate-proxy"
+              cliArgs: "-f compose.yaml -f compose-with-corporate-proxy.yaml"
+          - os: ubuntu-24.04-arm
+            composeConfig:
+              name: "dynamic-plugins-root"
+              cliArgs: "-f compose.yaml -f compose-dynamic-plugins-root.yaml"
+          - os: ubuntu-24.04-arm
+            composeConfig:
+              name: "developer-lightspeed"
+              cliArgs: "-f compose.yaml -f developer-lightspeed/compose.yaml"
           # Skip developer-lightspeed on release-1.10 branch
           - branch: "release-1.10"
             composeConfig:


### PR DESCRIPTION
## Description

ARM tests verify architecture compatibility, not functional differences that vary by compose config or container tool. Running the full matrix on ARM (~76 jobs) is unnecessary.

This reduces the ARM nightly matrix to a representative subset per branch:
- Container tool: `docker` only
- Compose configs: `default` + `orchestrator-workflow` only
- User config: `false` only

This brings ARM jobs down from ~76 to ~8 (2 per branch). The full x86 matrix is unchanged.

## Which issue(s) does this PR fix or relate to

N/A

## PR acceptance criteria

- [x] Tests updated and passing
- [ ] Documentation updated
- [x] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

## How to test changes / Special notes to the reviewer