### PR TITLE
ci(nightly): skip developer-lightspeed on `main` and `release-1.10`

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -65,8 +65,8 @@ jobs:
             cliArgs: "-f compose.yaml -f compose-dynamic-plugins-root.yaml"
           - name: "orchestrator-workflow"
             cliArgs: "-f compose.yaml -f orchestrator/compose.yaml"
-          # TODO: Remove this and the exclude rule below when the minimum supported version is 1.10
-          # (with Lightspeed enabled by default)
+          # TODO: Remove this and the exclude rules below once all supported
+          # branches include Lightspeed in the base deployment.
           - name: "developer-lightspeed"
             cliArgs: "-f compose.yaml -f developer-lightspeed/compose.yaml"
         exclude:
@@ -89,7 +89,12 @@ jobs:
             composeConfig:
               name: "developer-lightspeed"
               cliArgs: "-f compose.yaml -f developer-lightspeed/compose.yaml"
-          # Skip developer-lightspeed on release-1.10 branch
+          # Skip developer-lightspeed on main and release-1.10: Lightspeed is
+          # fully integrated with the base deployment.
+          - branch: "main"
+            composeConfig:
+              name: "developer-lightspeed"
+              cliArgs: "-f compose.yaml -f developer-lightspeed/compose.yaml"
           - branch: "release-1.10"
             composeConfig:
               name: "developer-lightspeed"


### PR DESCRIPTION
## Description

Lightspeed is fully integrated with the base deployment on `main` and `release-1.10`, so the separate `developer-lightspeed` compose overlay is redundant for those branches.

This adds a matrix exclusion for `main` (matching the existing one for `release-1.10`) and updates the TODO comment to reflect when the config and exclude rules can be fully removed (once all supported branches include Lightspeed in the base deployment).

## Which issue(s) does this PR fix or relate to

https://github.com/redhat-developer/rhdh-local/actions/runs/27821414144/job/82335212290

## PR acceptance criteria

- [x] Tests updated and passing
- [ ] Documentation updated
- [x] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

## How to test changes / Special notes to the reviewer
