### PR TITLE
chore(agent-readiness): bootstrap basic AGENTS.md and minor repo updates

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "FILE=\"$CLAUDE_FILE_PATH\"; case \"$FILE\" in *.yaml|*.yml) npx --yes dclint \"$FILE\" 2>/dev/null || true ;; *.sh) shellcheck \"$FILE\" 2>/dev/null || true ;; esac"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ generated/
 
 **/.DS_Store
 .idea
+*.swp
+*.swo
+.vscode/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# rhdh-local
+
+Red Hat Developer Hub (RHDH) Local — a Docker/Podman Compose setup for running RHDH locally for development and testing. Not a substitute for production RHDH; intended for individual developer use on a laptop/desktop.
+
+## Build & Test Commands
+
+- Start: `podman compose up -d` (or `docker compose up -d`)
+- Stop RHDH only: `podman compose stop rhdh`
+- Stop all: `podman compose down`
+- Teardown (including volumes): `podman compose down --volumes`
+- Reinstall plugins then restart RHDH: `podman compose run install-dynamic-plugins && podman compose stop rhdh && podman compose start rhdh`
+- Lint all compose files: `npx dclint .`
+- Lint single compose file: `npx dclint <file.yaml>`
+- Lint shell scripts: `shellcheck *.sh`
+- Lint single shell script: `shellcheck <script.sh>`
+
+## Single-File Verification
+
+- Compose/YAML file: `npx dclint <file.yaml>`
+- Shell script: `shellcheck <script.sh>`
+
+## Key Conventions
+
+<!-- TODO (maintainers): Add 2-3 conventions that an agent couldn't discover by reading the code.
+     Examples: naming conventions for compose override files, how *.local.yaml files work,
+     how dynamic plugin configs are structured, or how user configs interact with default.env. -->
+
+## Architecture
+
+<!-- TODO (maintainers): Add non-obvious architectural decisions or places where things live
+     unexpectedly. Examples: why configs/ is laid out as it is, how compose overlay files
+     relate to compose.yaml, how prepare-and-install-dynamic-plugins.sh interacts with
+     the dynamic-plugins-root compose variant, or how the wait-for-plugins-and-start.sh
+     startup sequence works. -->
+
+## PR Conventions
+
+- Conventional Commits are used: `fix:`, `feat:`, `chore:`, `ci:`, `docs:`, etc.
+- Scope examples: `nightly`, `deps`, `lightspeed`, `plugins`
+- Agent-assisted commits should include an `Assisted-by: <model>` footer
+- Report issues to Jira project RHIDP with Component: **RHDH Local**
+
+## Pattern References
+
+- Compose overlay: see `compose-with-corporate-proxy.yaml` for how to extend `compose.yaml`
+- Dynamic plugins config: see files in `configs/dynamic-plugins/` for plugin configuration patterns
+- Orchestrator integration: see `orchestrator/compose.yaml` for adding services via overlay
+- Shell utility scripts: see `prepare-and-install-dynamic-plugins.sh` and `wait-for-plugins-and-start.sh`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.PHONY: start stop restart clean plugins-install lint
+
+## Start RHDH Local (default Podman; set TOOL=docker to use Docker)
+TOOL ?= podman
+
+start:
+	$(TOOL) compose up -d
+
+stop:
+	$(TOOL) compose down
+
+restart: stop start
+
+clean:
+	$(TOOL) compose down --volumes
+
+plugins-install:
+	$(TOOL) compose run install-dynamic-plugins
+	$(TOOL) compose stop rhdh
+	$(TOOL) compose start rhdh
+
+lint:
+	npx dclint .
+	shellcheck *.sh


### PR DESCRIPTION
## Description

Ran the agent-ready (https://github.com/redhat-developer/rhdh-skill/blob/main/skills/agent-ready/SKILL.md) skill against the repository, to address some gaps called out by the https://github.com/ambient-code/agentready CLI (to assess an individual repository's readiness to be consumed by agents). 

- Adds an AGENTS.md / CLAUDE.md with basic one-line build and test commands, and a link to some repo docs that could be found
    - **To the maintainers:** I recommend populating the Key convention and Architecture sections for stuff that isn't immediately obvious to an agent
        - **Do not** auto generate this information, as it can actively harm agent effectiveness
- A couple minor updates to the repo and a claude hook to improve agent consumption

## Which issue(s) does this PR fix or relate to

N/A, but see https://docs.google.com/spreadsheets/d/1Gk3nDQFJ2PBaaPiMZ3naJqAWf-nmL14OwK-Y83k7cuc/edit for more information

## PR acceptance criteria

- [ ] Tests
- [x] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
