### PR TITLE
chore: bump Lightspeed Core Service to 0.5.2

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -98,7 +98,7 @@ services:
   # Default image: quay.io/lightspeed-core/lightspeed-stack:0.5.1
   # To override: Set LIGHTSPEED_CORE_IMAGE in your .env file
   lightspeed-core:
-    image: ${LIGHTSPEED_CORE_IMAGE:-quay.io/lightspeed-core/lightspeed-stack:0.5.1} # dclint disable-line service-image-require-explicit-tag
+    image: ${LIGHTSPEED_CORE_IMAGE:-quay.io/lightspeed-core/lightspeed-stack:0.5.2} # dclint disable-line service-image-require-explicit-tag
     container_name: lightspeed-core
     network_mode: "service:rhdh"
     depends_on:


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description

Patches Lightspeed Core Service (or Lightspeed Stack) to use v0.5.2.

## Which issue(s) does this PR fix or relate to

- https://redhat.atlassian.net/browse/RHIDP-14724

## PR acceptance criteria

- [ ] Tests updated and passing
- [ ] Documentation updated
- [ ] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
