### PR TITLE
ci: validate loaded plugins after RHDH startup

### DIFF
--- a/.github/actions/rhdh-local-compose-test/action.yaml
+++ b/.github/actions/rhdh-local-compose-test/action.yaml
@@ -240,6 +240,16 @@ runs:
         # Custom components.override.yaml
         cp configs/catalog-entities/components.override.example.yaml configs/catalog-entities/components.override.yaml
 
+    - name: Add orchestrator plugins to dynamic-plugins override
+      if: ${{ env.SKIP_TEST != 'true' && contains(inputs.compose_config_name, 'orchestrator') }}
+      shell: bash
+      run: |
+        OVERRIDE="configs/dynamic-plugins/dynamic-plugins.override.yaml"
+        if [ ! -f "$OVERRIDE" ]; then
+          cp configs/dynamic-plugins/dynamic-plugins.yaml "$OVERRIDE"
+        fi
+        yq -i '.plugins += load("orchestrator/configs/dynamic-plugins/dynamic-plugins.yaml").plugins' "$OVERRIDE"
+
     - name: Create dynamic plugins directory
       if: ${{ env.SKIP_TEST != 'true' && inputs.compose_config_name == 'dynamic-plugins-root' }}
       shell: bash
@@ -279,12 +289,7 @@ runs:
     - name: Validate loaded plugins
       if: ${{ env.SKIP_TEST != 'true' }}
       shell: bash
-      run: |
-        extra_configs=()
-        if [[ "${{ inputs.compose_config_name }}" == *orchestrator* ]]; then
-          extra_configs+=("orchestrator/configs/dynamic-plugins/dynamic-plugins.yaml")
-        fi
-        ./tests/validate-loaded-plugins.sh "${extra_configs[@]}"
+      run: ./tests/validate-loaded-plugins.sh
 
     - name: curl from RHDH Container (for troubleshooting)
       if: ${{ failure() && env.SKIP_TEST != 'true' }}

--- a/.github/actions/rhdh-local-compose-test/action.yaml
+++ b/.github/actions/rhdh-local-compose-test/action.yaml
@@ -240,6 +240,8 @@ runs:
         # Custom components.override.yaml
         cp configs/catalog-entities/components.override.example.yaml configs/catalog-entities/components.override.yaml
 
+    # Orchestrator plugins must be added directly to the override file.
+    # See orchestrator/README.md#setup-orchestrator-and-workflow-examples
     - name: Add orchestrator plugins to dynamic-plugins override
       if: ${{ env.SKIP_TEST != 'true' && contains(inputs.compose_config_name, 'orchestrator') }}
       shell: bash

--- a/.github/actions/rhdh-local-compose-test/action.yaml
+++ b/.github/actions/rhdh-local-compose-test/action.yaml
@@ -276,6 +276,16 @@ runs:
         echo "[$(date)] RHDH is ready"
         curl -i --insecure http://localhost:7007
 
+    - name: Validate loaded plugins
+      if: ${{ env.SKIP_TEST != 'true' }}
+      shell: bash
+      run: |
+        extra_configs=()
+        if [[ "${{ inputs.compose_config_name }}" == *orchestrator* ]]; then
+          extra_configs+=("orchestrator/configs/dynamic-plugins/dynamic-plugins.yaml")
+        fi
+        ./tests/validate-loaded-plugins.sh "${extra_configs[@]}"
+
     - name: curl from RHDH Container (for troubleshooting)
       if: ${{ failure() && env.SKIP_TEST != 'true' }}
       shell: bash

--- a/tests/validate-loaded-plugins.sh
+++ b/tests/validate-loaded-plugins.sh
@@ -94,8 +94,8 @@ guest_response=$(curl -sS -f "${RHDH_URL}/api/auth/guest/refresh" \
     -H "Accept: application/json" 2>/dev/null) || true
 RHDH_TOKEN=$(echo "$guest_response" | jq -r '.backstageIdentity.token // empty' 2>/dev/null)
 if [[ -z "$RHDH_TOKEN" ]]; then
-    echo "ERROR: Could not obtain guest auth token."
-    echo "Response: $guest_response"
+    echo "ERROR: Could not obtain guest auth token." >&2
+    echo "Response: $guest_response" >&2
     exit 1
 fi
 echo "Guest auth token obtained."
@@ -107,17 +107,17 @@ http_code=$(curl -sS -o /tmp/loaded-plugins.json -w "%{http_code}" \
     "${RHDH_URL}/api/extensions/loaded-plugins") || true
 
 if [[ "$http_code" != "200" ]]; then
-    echo "ERROR: Could not reach loaded-plugins endpoint (HTTP $http_code)."
-    echo "Response body:"
-    cat /tmp/loaded-plugins.json 2>/dev/null || true
+    echo "ERROR: Could not reach loaded-plugins endpoint (HTTP $http_code)." >&2
+    echo "Response body:" >&2
+    cat /tmp/loaded-plugins.json >&2 2>/dev/null || true
     exit 1
 fi
 
 loaded_names=$(jq -r '.[].name' /tmp/loaded-plugins.json 2>/dev/null)
 if [[ -z "$loaded_names" ]]; then
-    echo "ERROR: Loaded plugins response was empty or could not be parsed."
-    echo "Response body:"
-    cat /tmp/loaded-plugins.json 2>/dev/null || true
+    echo "ERROR: Loaded plugins response was empty or could not be parsed." >&2
+    echo "Response body:" >&2
+    cat /tmp/loaded-plugins.json >&2 2>/dev/null || true
     exit 1
 fi
 
@@ -144,7 +144,7 @@ if [[ ${#expected_plugins[@]} -gt 0 ]]; then
         if $found; then
             echo "  [PASS] $name"
         else
-            echo "  [FAIL] $name (normalized: $norm_expected) -- not found in loaded plugins"
+            echo "  [FAIL] $name (normalized: $norm_expected) -- not found in loaded plugins" >&2
             failed=$((failed + 1))
         fi
     done
@@ -163,7 +163,7 @@ if [[ ${#disabled_plugins[@]} -gt 0 ]]; then
             fi
         done
         if $found; then
-            echo "  [FAIL] $name (normalized: $norm_disabled) -- should not be loaded"
+            echo "  [FAIL] $name (normalized: $norm_disabled) -- should not be loaded" >&2
             failed=$((failed + 1))
         else
             echo "  [PASS] $name"
@@ -173,7 +173,7 @@ fi
 
 echo ""
 if [[ $failed -gt 0 ]]; then
-    echo "FAILED: $failed plugin validation(s) failed."
+    echo "FAILED: $failed plugin validation(s) failed." >&2
     echo ""
     echo "Loaded plugins:"
     jq -r '.[].name' /tmp/loaded-plugins.json | sort

--- a/tests/validate-loaded-plugins.sh
+++ b/tests/validate-loaded-plugins.sh
@@ -18,10 +18,9 @@ set -euo pipefail
 RHDH_URL="${RHDH_URL:-http://localhost:7007}"
 DYN_PLUGINS_DIR="configs/dynamic-plugins"
 
+primary_config="$DYN_PLUGINS_DIR/dynamic-plugins.yaml"
 if [[ -f "$DYN_PLUGINS_DIR/dynamic-plugins.override.yaml" ]]; then
     primary_config="$DYN_PLUGINS_DIR/dynamic-plugins.override.yaml"
-else
-    primary_config="$DYN_PLUGINS_DIR/dynamic-plugins.yaml"
 fi
 
 config_files=("$primary_config")
@@ -46,7 +45,7 @@ extract_plugin_name() {
         return
     fi
     local name="${pkg##*/}"
-    name="${name%%:*}"
+    name="${name%%:*}" # strip tag (e.g. :v1.2.3 or :{{inherit}})
     echo "$name"
 }
 

--- a/tests/validate-loaded-plugins.sh
+++ b/tests/validate-loaded-plugins.sh
@@ -95,9 +95,9 @@ guest_response=$(curl -sS -f "${RHDH_URL}/api/auth/guest/refresh" \
     -H "Accept: application/json" 2>/dev/null) || true
 RHDH_TOKEN=$(echo "$guest_response" | jq -r '.backstageIdentity.token // empty' 2>/dev/null)
 if [[ -z "$RHDH_TOKEN" ]]; then
-    echo "WARNING: Could not obtain guest auth token. Skipping validation."
+    echo "ERROR: Could not obtain guest auth token."
     echo "Response: $guest_response"
-    exit 0
+    exit 1
 fi
 echo "Guest auth token obtained."
 
@@ -108,18 +108,18 @@ http_code=$(curl -sS -o /tmp/loaded-plugins.json -w "%{http_code}" \
     "${RHDH_URL}/api/extensions/loaded-plugins") || true
 
 if [[ "$http_code" != "200" ]]; then
-    echo "WARNING: Could not reach loaded-plugins endpoint (HTTP $http_code). Skipping validation."
+    echo "ERROR: Could not reach loaded-plugins endpoint (HTTP $http_code)."
     echo "Response body:"
     cat /tmp/loaded-plugins.json 2>/dev/null || true
-    exit 0
+    exit 1
 fi
 
 loaded_names=$(jq -r '.[].name' /tmp/loaded-plugins.json 2>/dev/null)
 if [[ -z "$loaded_names" ]]; then
-    echo "WARNING: Loaded plugins response was empty or could not be parsed."
+    echo "ERROR: Loaded plugins response was empty or could not be parsed."
     echo "Response body:"
     cat /tmp/loaded-plugins.json 2>/dev/null || true
-    exit 0
+    exit 1
 fi
 
 # Build a list of normalized loaded plugin names for matching.

--- a/tests/validate-loaded-plugins.sh
+++ b/tests/validate-loaded-plugins.sh
@@ -15,6 +15,9 @@
 
 set -euo pipefail
 
+tmpfile=$(mktemp)
+trap 'rm -f "$tmpfile"' EXIT
+
 for cmd in yq jq curl; do
     if ! command -v "$cmd" &>/dev/null; then
         echo "ERROR: Required command '$cmd' not found." >&2
@@ -114,22 +117,22 @@ echo "Guest auth token obtained."
 
 echo ""
 echo "Fetching loaded plugins from ${RHDH_URL}/api/extensions/loaded-plugins ..."
-http_code=$(curl -sS -o /tmp/loaded-plugins.json -w "%{http_code}" \
+http_code=$(curl -sS -o $tmpfile -w "%{http_code}" \
     -H "Authorization: Bearer ${RHDH_TOKEN}" \
     "${RHDH_URL}/api/extensions/loaded-plugins") || true
 
 if [[ "$http_code" != "200" ]]; then
     echo "ERROR: Could not reach loaded-plugins endpoint (HTTP $http_code)." >&2
     echo "Response body:" >&2
-    cat /tmp/loaded-plugins.json >&2 2>/dev/null || true
+    cat $tmpfile >&2 2>/dev/null || true
     exit 1
 fi
 
-loaded_names=$(jq -r '.[].name' /tmp/loaded-plugins.json 2>/dev/null)
+loaded_names=$(jq -r '.[].name' $tmpfile 2>/dev/null)
 if [[ -z "$loaded_names" ]]; then
     echo "ERROR: Loaded plugins response was empty or could not be parsed." >&2
     echo "Response body:" >&2
-    cat /tmp/loaded-plugins.json >&2 2>/dev/null || true
+    cat $tmpfile >&2 2>/dev/null || true
     exit 1
 fi
 
@@ -188,7 +191,7 @@ if [[ $failed -gt 0 ]]; then
     echo "FAILED: $failed plugin validation(s) failed." >&2
     echo ""
     echo "Loaded plugins:"
-    jq -r '.[].name' /tmp/loaded-plugins.json | sort
+    jq -r '.[].name' $tmpfile | sort
     exit 1
 fi
 

--- a/tests/validate-loaded-plugins.sh
+++ b/tests/validate-loaded-plugins.sh
@@ -15,6 +15,13 @@
 
 set -euo pipefail
 
+for cmd in yq jq curl; do
+    if ! command -v "$cmd" &>/dev/null; then
+        echo "ERROR: Required command '$cmd' not found." >&2
+        exit 1
+    fi
+done
+
 RHDH_URL="${RHDH_URL:-http://localhost:7007}"
 DYN_PLUGINS_DIR="configs/dynamic-plugins"
 
@@ -61,26 +68,31 @@ normalize_plugin_name() {
     echo "$name"
 }
 
-# Extract plugin names that should be enabled (not explicitly disabled).
 expected_plugins=()
-for cfg in "${config_files[@]}"; do
-    while IFS= read -r raw_pkg; do
-        [[ -z "$raw_pkg" ]] && continue
-        raw_pkg="${raw_pkg//\'/}"
-        raw_pkg="${raw_pkg//\"/}"
-        expected_plugins+=("$(extract_plugin_name "$raw_pkg")")
-    done < <(yq '.plugins[] | select(.disabled != true and .enabled != false) | .package' "$cfg" 2>/dev/null)
-done
-
-# Extract plugin names that should NOT be loaded (explicitly disabled).
 disabled_plugins=()
 for cfg in "${config_files[@]}"; do
+    if ! yq -e '.plugins' "$cfg" > /dev/null 2>&1; then
+        echo "Config $cfg has no .plugins array, skipping."
+        continue
+    fi
+
+    enabled_output=$(yq -r '.plugins[] | select(.disabled != true and .enabled != false) | .package' "$cfg") || {
+        echo "ERROR: Failed to extract enabled plugins from $cfg" >&2
+        exit 1
+    }
     while IFS= read -r raw_pkg; do
         [[ -z "$raw_pkg" ]] && continue
-        raw_pkg="${raw_pkg//\'/}"
-        raw_pkg="${raw_pkg//\"/}"
+        expected_plugins+=("$(extract_plugin_name "$raw_pkg")")
+    done <<< "$enabled_output"
+
+    disabled_output=$(yq -r '.plugins[] | select(.disabled == true or .enabled == false) | .package' "$cfg") || {
+        echo "ERROR: Failed to extract disabled plugins from $cfg" >&2
+        exit 1
+    }
+    while IFS= read -r raw_pkg; do
+        [[ -z "$raw_pkg" ]] && continue
         disabled_plugins+=("$(extract_plugin_name "$raw_pkg")")
-    done < <(yq '.plugins[] | select(.disabled == true or .enabled == false) | .package' "$cfg" 2>/dev/null)
+    done <<< "$disabled_output"
 done
 
 if [[ ${#expected_plugins[@]} -eq 0 ]] && [[ ${#disabled_plugins[@]} -eq 0 ]]; then

--- a/tests/validate-loaded-plugins.sh
+++ b/tests/validate-loaded-plugins.sh
@@ -12,6 +12,7 @@
 # The script determines the effective dynamic-plugins config
 # (override if it exists, else default) and parses it using yq.
 # Any extra config files (e.g., orchestrator) can be passed as arguments.
+# Assumes CWD is the repository root.
 
 set -euo pipefail
 
@@ -106,7 +107,7 @@ fi
 echo ""
 echo "Obtaining guest auth token from ${RHDH_URL}/api/auth/guest/refresh ..."
 guest_response=$(curl -sS -f "${RHDH_URL}/api/auth/guest/refresh" \
-    -H "Accept: application/json" 2>/dev/null) || true
+    -H "Accept: application/json")
 RHDH_TOKEN=$(echo "$guest_response" | jq -r '.backstageIdentity.token // empty' 2>/dev/null)
 if [[ -z "$RHDH_TOKEN" ]]; then
     echo "ERROR: Could not obtain guest auth token." >&2
@@ -119,7 +120,7 @@ echo ""
 echo "Fetching loaded plugins from ${RHDH_URL}/api/extensions/loaded-plugins ..."
 http_code=$(curl -sS -o "$tmpfile" -w "%{http_code}" \
     -H "Authorization: Bearer ${RHDH_TOKEN}" \
-    "${RHDH_URL}/api/extensions/loaded-plugins") || true
+    "${RHDH_URL}/api/extensions/loaded-plugins")
 
 if [[ "$http_code" != "200" ]]; then
     echo "ERROR: Could not reach loaded-plugins endpoint (HTTP $http_code)." >&2

--- a/tests/validate-loaded-plugins.sh
+++ b/tests/validate-loaded-plugins.sh
@@ -117,22 +117,22 @@ echo "Guest auth token obtained."
 
 echo ""
 echo "Fetching loaded plugins from ${RHDH_URL}/api/extensions/loaded-plugins ..."
-http_code=$(curl -sS -o $tmpfile -w "%{http_code}" \
+http_code=$(curl -sS -o "$tmpfile" -w "%{http_code}" \
     -H "Authorization: Bearer ${RHDH_TOKEN}" \
     "${RHDH_URL}/api/extensions/loaded-plugins") || true
 
 if [[ "$http_code" != "200" ]]; then
     echo "ERROR: Could not reach loaded-plugins endpoint (HTTP $http_code)." >&2
     echo "Response body:" >&2
-    cat $tmpfile >&2 2>/dev/null || true
+    cat "$tmpfile" >&2 2>/dev/null || true
     exit 1
 fi
 
-loaded_names=$(jq -r '.[].name' $tmpfile 2>/dev/null)
+loaded_names=$(jq -r '.[].name' "$tmpfile" 2>/dev/null)
 if [[ -z "$loaded_names" ]]; then
     echo "ERROR: Loaded plugins response was empty or could not be parsed." >&2
     echo "Response body:" >&2
-    cat $tmpfile >&2 2>/dev/null || true
+    cat "$tmpfile" >&2 2>/dev/null || true
     exit 1
 fi
 
@@ -191,7 +191,7 @@ if [[ $failed -gt 0 ]]; then
     echo "FAILED: $failed plugin validation(s) failed." >&2
     echo ""
     echo "Loaded plugins:"
-    jq -r '.[].name' $tmpfile | sort
+    jq -r '.[].name' "$tmpfile" | sort
     exit 1
 fi
 

--- a/tests/validate-loaded-plugins.sh
+++ b/tests/validate-loaded-plugins.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+# Validates that explicitly configured dynamic plugins are actually loaded
+# in the running RHDH instance by querying /api/extensions/loaded-plugins.
+#
+# Usage: ./tests/validate-loaded-plugins.sh [additional-config-files...]
+# Environment:
+#   RHDH_URL - Base URL of the RHDH instance (default: http://localhost:7007)
+#
+# Authenticates via guest auth (GET /api/auth/guest/refresh) to obtain
+# a Backstage identity token, then queries /api/extensions/loaded-plugins.
+#
+# The script determines the effective dynamic-plugins config
+# (override if it exists, else default) and parses it using yq.
+# Any extra config files (e.g., orchestrator) can be passed as arguments.
+
+set -euo pipefail
+
+RHDH_URL="${RHDH_URL:-http://localhost:7007}"
+DYN_PLUGINS_DIR="configs/dynamic-plugins"
+
+if [ -f "$DYN_PLUGINS_DIR/dynamic-plugins.override.yaml" ]; then
+    primary_config="$DYN_PLUGINS_DIR/dynamic-plugins.override.yaml"
+else
+    primary_config="$DYN_PLUGINS_DIR/dynamic-plugins.yaml"
+fi
+
+config_files=("$primary_config")
+for extra in "$@"; do
+    if [ -f "$extra" ]; then
+        config_files+=("$extra")
+    else
+        echo "WARNING: Extra config file not found, skipping: $extra"
+    fi
+done
+
+echo "Config files: ${config_files[*]}"
+
+# Extract the raw plugin name from a package reference.
+# ./dynamic-plugins/dist/foo → foo
+# oci://host/path/foo:tag → foo
+# oci://host/path/foo:tag!bar → bar
+extract_plugin_name() {
+    local pkg="$1"
+    if [[ "$pkg" == *"!"* ]]; then
+        echo "${pkg##*!}"
+        return
+    fi
+    local name="${pkg##*/}"
+    name="${name%%:*}"
+    echo "$name"
+}
+
+# Normalize a plugin name so OCI image names and npm scoped package names
+# can be compared. For example:
+#   @backstage-community/plugin-quay-backend-dynamic → backstage-community-plugin-quay-backend
+#   backstage-community-plugin-quay-backend          → backstage-community-plugin-quay-backend
+normalize_plugin_name() {
+    local name="$1"
+    name="${name#@}"
+    name="${name//\//-}"
+    name="${name%-dynamic}"
+    echo "$name"
+}
+
+# Extract plugin names that should be enabled (not explicitly disabled).
+expected_plugins=()
+for cfg in "${config_files[@]}"; do
+    while IFS= read -r raw_pkg; do
+        [ -z "$raw_pkg" ] && continue
+        raw_pkg="${raw_pkg//\'/}"
+        raw_pkg="${raw_pkg//\"/}"
+        expected_plugins+=("$(extract_plugin_name "$raw_pkg")")
+    done < <(yq '.plugins[] | select(.disabled != true and .enabled != false) | .package' "$cfg" 2>/dev/null)
+done
+
+# Extract plugin names that should NOT be loaded (explicitly disabled).
+disabled_plugins=()
+for cfg in "${config_files[@]}"; do
+    while IFS= read -r raw_pkg; do
+        [ -z "$raw_pkg" ] && continue
+        raw_pkg="${raw_pkg//\'/}"
+        raw_pkg="${raw_pkg//\"/}"
+        disabled_plugins+=("$(extract_plugin_name "$raw_pkg")")
+    done < <(yq '.plugins[] | select(.disabled == true or .enabled == false) | .package' "$cfg" 2>/dev/null)
+done
+
+if [ ${#expected_plugins[@]} -eq 0 ] && [ ${#disabled_plugins[@]} -eq 0 ]; then
+    echo "WARNING: No plugins found in config files. Nothing to validate."
+    exit 0
+fi
+
+echo ""
+echo "Obtaining guest auth token from ${RHDH_URL}/api/auth/guest/refresh ..."
+guest_response=$(curl -sS -f "${RHDH_URL}/api/auth/guest/refresh" \
+    -H "Accept: application/json" 2>/dev/null) || true
+RHDH_TOKEN=$(echo "$guest_response" | jq -r '.backstageIdentity.token // empty' 2>/dev/null)
+if [ -z "$RHDH_TOKEN" ]; then
+    echo "WARNING: Could not obtain guest auth token. Skipping validation."
+    echo "Response: $guest_response"
+    exit 0
+fi
+echo "Guest auth token obtained."
+
+echo ""
+echo "Fetching loaded plugins from ${RHDH_URL}/api/extensions/loaded-plugins ..."
+http_code=$(curl -sS -o /tmp/loaded-plugins.json -w "%{http_code}" \
+    -H "Authorization: Bearer ${RHDH_TOKEN}" \
+    "${RHDH_URL}/api/extensions/loaded-plugins") || true
+
+if [ "$http_code" != "200" ]; then
+    echo "WARNING: Could not reach loaded-plugins endpoint (HTTP $http_code). Skipping validation."
+    echo "Response body:"
+    cat /tmp/loaded-plugins.json 2>/dev/null || true
+    exit 0
+fi
+
+loaded_names=$(jq -r '.[].name' /tmp/loaded-plugins.json 2>/dev/null)
+if [ -z "$loaded_names" ]; then
+    echo "WARNING: Loaded plugins response was empty or could not be parsed."
+    echo "Response body:"
+    cat /tmp/loaded-plugins.json 2>/dev/null || true
+    exit 0
+fi
+
+# Build a list of normalized loaded plugin names for matching.
+normalized_loaded=()
+while IFS= read -r loaded; do
+    normalized_loaded+=("$(normalize_plugin_name "$loaded")")
+done <<< "$loaded_names"
+
+failed=0
+
+if [ ${#expected_plugins[@]} -gt 0 ]; then
+    echo ""
+    echo "Validating ${#expected_plugins[@]} expected plugin(s) are loaded:"
+    for name in "${expected_plugins[@]}"; do
+        norm_expected=$(normalize_plugin_name "$name")
+        found=false
+        for norm_loaded in "${normalized_loaded[@]}"; do
+            if [ "$norm_expected" = "$norm_loaded" ]; then
+                found=true
+                break
+            fi
+        done
+        if $found; then
+            echo "  [PASS] $name"
+        else
+            echo "  [FAIL] $name (normalized: $norm_expected) -- not found in loaded plugins"
+            failed=$((failed + 1))
+        fi
+    done
+fi
+
+if [ ${#disabled_plugins[@]} -gt 0 ]; then
+    echo ""
+    echo "Validating ${#disabled_plugins[@]} disabled plugin(s) are NOT loaded:"
+    for name in "${disabled_plugins[@]}"; do
+        norm_disabled=$(normalize_plugin_name "$name")
+        found=false
+        for norm_loaded in "${normalized_loaded[@]}"; do
+            if [ "$norm_disabled" = "$norm_loaded" ]; then
+                found=true
+                break
+            fi
+        done
+        if $found; then
+            echo "  [FAIL] $name (normalized: $norm_disabled) -- should not be loaded"
+            failed=$((failed + 1))
+        else
+            echo "  [PASS] $name"
+        fi
+    done
+fi
+
+echo ""
+if [ $failed -gt 0 ]; then
+    echo "FAILED: $failed plugin validation(s) failed."
+    echo ""
+    echo "Loaded plugins:"
+    jq -r '.[].name' /tmp/loaded-plugins.json | sort
+    exit 1
+fi
+
+echo "All plugin validations passed."

--- a/tests/validate-loaded-plugins.sh
+++ b/tests/validate-loaded-plugins.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 RHDH_URL="${RHDH_URL:-http://localhost:7007}"
 DYN_PLUGINS_DIR="configs/dynamic-plugins"
 
-if [ -f "$DYN_PLUGINS_DIR/dynamic-plugins.override.yaml" ]; then
+if [[ -f "$DYN_PLUGINS_DIR/dynamic-plugins.override.yaml" ]]; then
     primary_config="$DYN_PLUGINS_DIR/dynamic-plugins.override.yaml"
 else
     primary_config="$DYN_PLUGINS_DIR/dynamic-plugins.yaml"
@@ -26,7 +26,7 @@ fi
 
 config_files=("$primary_config")
 for extra in "$@"; do
-    if [ -f "$extra" ]; then
+    if [[ -f "$extra" ]]; then
         config_files+=("$extra")
     else
         echo "WARNING: Extra config file not found, skipping: $extra"
@@ -66,7 +66,7 @@ normalize_plugin_name() {
 expected_plugins=()
 for cfg in "${config_files[@]}"; do
     while IFS= read -r raw_pkg; do
-        [ -z "$raw_pkg" ] && continue
+        [[ -z "$raw_pkg" ]] && continue
         raw_pkg="${raw_pkg//\'/}"
         raw_pkg="${raw_pkg//\"/}"
         expected_plugins+=("$(extract_plugin_name "$raw_pkg")")
@@ -77,14 +77,14 @@ done
 disabled_plugins=()
 for cfg in "${config_files[@]}"; do
     while IFS= read -r raw_pkg; do
-        [ -z "$raw_pkg" ] && continue
+        [[ -z "$raw_pkg" ]] && continue
         raw_pkg="${raw_pkg//\'/}"
         raw_pkg="${raw_pkg//\"/}"
         disabled_plugins+=("$(extract_plugin_name "$raw_pkg")")
     done < <(yq '.plugins[] | select(.disabled == true or .enabled == false) | .package' "$cfg" 2>/dev/null)
 done
 
-if [ ${#expected_plugins[@]} -eq 0 ] && [ ${#disabled_plugins[@]} -eq 0 ]; then
+if [[ ${#expected_plugins[@]} -eq 0 ]] && [[ ${#disabled_plugins[@]} -eq 0 ]]; then
     echo "WARNING: No plugins found in config files. Nothing to validate."
     exit 0
 fi
@@ -94,7 +94,7 @@ echo "Obtaining guest auth token from ${RHDH_URL}/api/auth/guest/refresh ..."
 guest_response=$(curl -sS -f "${RHDH_URL}/api/auth/guest/refresh" \
     -H "Accept: application/json" 2>/dev/null) || true
 RHDH_TOKEN=$(echo "$guest_response" | jq -r '.backstageIdentity.token // empty' 2>/dev/null)
-if [ -z "$RHDH_TOKEN" ]; then
+if [[ -z "$RHDH_TOKEN" ]]; then
     echo "WARNING: Could not obtain guest auth token. Skipping validation."
     echo "Response: $guest_response"
     exit 0
@@ -107,7 +107,7 @@ http_code=$(curl -sS -o /tmp/loaded-plugins.json -w "%{http_code}" \
     -H "Authorization: Bearer ${RHDH_TOKEN}" \
     "${RHDH_URL}/api/extensions/loaded-plugins") || true
 
-if [ "$http_code" != "200" ]; then
+if [[ "$http_code" != "200" ]]; then
     echo "WARNING: Could not reach loaded-plugins endpoint (HTTP $http_code). Skipping validation."
     echo "Response body:"
     cat /tmp/loaded-plugins.json 2>/dev/null || true
@@ -115,7 +115,7 @@ if [ "$http_code" != "200" ]; then
 fi
 
 loaded_names=$(jq -r '.[].name' /tmp/loaded-plugins.json 2>/dev/null)
-if [ -z "$loaded_names" ]; then
+if [[ -z "$loaded_names" ]]; then
     echo "WARNING: Loaded plugins response was empty or could not be parsed."
     echo "Response body:"
     cat /tmp/loaded-plugins.json 2>/dev/null || true
@@ -130,14 +130,14 @@ done <<< "$loaded_names"
 
 failed=0
 
-if [ ${#expected_plugins[@]} -gt 0 ]; then
+if [[ ${#expected_plugins[@]} -gt 0 ]]; then
     echo ""
     echo "Validating ${#expected_plugins[@]} expected plugin(s) are loaded:"
     for name in "${expected_plugins[@]}"; do
         norm_expected=$(normalize_plugin_name "$name")
         found=false
         for norm_loaded in "${normalized_loaded[@]}"; do
-            if [ "$norm_expected" = "$norm_loaded" ]; then
+            if [[ "$norm_expected" = "$norm_loaded" ]]; then
                 found=true
                 break
             fi
@@ -151,14 +151,14 @@ if [ ${#expected_plugins[@]} -gt 0 ]; then
     done
 fi
 
-if [ ${#disabled_plugins[@]} -gt 0 ]; then
+if [[ ${#disabled_plugins[@]} -gt 0 ]]; then
     echo ""
     echo "Validating ${#disabled_plugins[@]} disabled plugin(s) are NOT loaded:"
     for name in "${disabled_plugins[@]}"; do
         norm_disabled=$(normalize_plugin_name "$name")
         found=false
         for norm_loaded in "${normalized_loaded[@]}"; do
-            if [ "$norm_disabled" = "$norm_loaded" ]; then
+            if [[ "$norm_disabled" = "$norm_loaded" ]]; then
                 found=true
                 break
             fi
@@ -173,7 +173,7 @@ if [ ${#disabled_plugins[@]} -gt 0 ]; then
 fi
 
 echo ""
-if [ $failed -gt 0 ]; then
+if [[ $failed -gt 0 ]]; then
     echo "FAILED: $failed plugin validation(s) failed."
     echo ""
     echo "Loaded plugins:"


### PR DESCRIPTION
## Description

The CI smoke tests only checked for HTTP 200 from the homepage, which meant some configuration changes could silently break plugin loading without CI catching it.

This checks the plugins that are loaded once RHDH is started and compares against the expected configuration.

## Which issue(s) does this PR fix or relate to

- Fixes [RHDHBUGS-3440](https://redhat.atlassian.net/browse/RHDHBUGS-3440)

## PR acceptance criteria

- [x] Tests updated and passing
- [ ] Documentation updated
- [ ] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

## How to test changes / Special notes to the reviewer

The checks on this PR are passing with the changes here, e.g.: https://github.com/redhat-developer/rhdh-local/actions/runs/28782801578/job/85342325860?pr=262#step:3:2001

To verify locally:
1. Start RHDH locally: `docker compose up -d`
2. Wait for it to be ready, then run: `./tests/validate-loaded-plugins.sh`
3. All configured plugins should show `[PASS]`
4. The disabled `global-floating-action-button` plugin should also show `[PASS]` (confirmed not loaded)

For orchestrator config, pass the extra config: `./tests/validate-loaded-plugins.sh orchestrator/configs/dynamic-plugins/dynamic-plugins.yaml`

Assisted-by: Claude