### PR TITLE
chore: generalize release-1.* branch patterns for 2.y support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - main
-      - release-1.[0-9]+
+      - release-[0-9]+.[0-9]+
   pull_request:
     branches:
       - main
-      - release-1.[0-9]+
+      - release-[0-9]+.[0-9]+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Generalizes the hardcoded `release-1.[0-9]+` branch-filter pattern in the test workflow to a digit-agnostic equivalent (`release-[0-9]+.[0-9]+`), so CI continues to trigger correctly once release branches move to `release-2.0` and beyond.
- No behavior change for existing `1.y` branches — verified via regex simulation that the new pattern matches both current `release-1.10`-style branches and future `release-2.0`/`release-10.3`-style branches, while still rejecting unrelated branches.

## Files changed
- `.github/workflows/test.yml`

## Context
Part of a broader upstream build-infrastructure audit for 2.y readiness across `rhdh-operator`, `rhdh-chart`, `rhdh-local`, and `red-hat-developers-documentation-rhdh`. Opened as draft to track review before the 2.0 branch cut.

## Test plan
- [ ] CI passes on this PR
- [ ] Confirm no regression for existing `release-1.y` triggers

Assisted-by [Cursor](https://cursor.com)

## Related
- RHIDP-11783
- RHIDP-13595
