### PR TITLE
fix: pin catalog index tag to 1.10.2

### DIFF
--- a/default.env
+++ b/default.env
@@ -13,7 +13,8 @@ BASE_URL=http://localhost:7007
 
 # Default plugin catalog index image
 # Requires RHDH 1.9+ to be handled.
-CATALOG_INDEX_IMAGE=quay.io/rhdh/plugin-catalog-index:1.10
+# TODO: Pinned due to issues with the floating 1.10 tag - see RHDHBUGS-3455 and RHDHBUGS-3492
+CATALOG_INDEX_IMAGE=quay.io/rhdh/plugin-catalog-index:1.10.2
 
 # Extra catalog index images (comma-separated).
 # Plugins from these images appear in the Extensions UI but are not installed by default.


### PR DESCRIPTION
## Description
1.10 seems to be pointing to an unreleased and unstable 1.10.3 tag, and this is causing some issues with RHDH Local.

## Which issue(s) does this PR fix or relate to

ref: RHDHBUGS-3455
ref: RHDHBUGS-3492

## PR acceptance criteria

- [ ] Tests updated and passing
- [ ] Documentation updated
- [ ] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
