### PR TITLE
docs: PostgreSQL major upgrade for RHDH Local

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -5,7 +5,7 @@ services:
 
   # db:
   #   container_name: db
-  #   image: "registry.redhat.io/rhel8/postgresql-16:latest"
+  #   image: "registry.redhat.io/rhel10/postgresql-18:latest"
   #   volumes:
   #     - "/var/lib/pgsql/data"
   #   env_file:

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,7 +14,8 @@ services:
   #     - path: "./.env"
   #       required: false
   #   environment:
-  #     - POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD}
+  #     # ${POSTGRES_PASSWORD} is taken from project `.env` or the shell (not from default.env).
+  #     - POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD:-postgres}
   #   healthcheck:
   #     test: ["CMD", "pg_isready", "-U", "postgres"]
   #     interval: 5s

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,8 +14,7 @@ services:
   #     - path: "./.env"
   #       required: false
   #   environment:
-  #     # ${POSTGRES_PASSWORD} is taken from project `.env` or the shell (not from default.env).
-  #     - POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD:-postgres}
+  #     - POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD}
   #   healthcheck:
   #     test: ["CMD", "pg_isready", "-U", "postgres"]
   #     interval: 5s

--- a/configs/dynamic-plugins/dynamic-plugins.override.example.yaml
+++ b/configs/dynamic-plugins/dynamic-plugins.override.example.yaml
@@ -21,11 +21,6 @@ includes:
   # - package: ./dynamic-plugins/dist/backstage-community-plugin-tech-radar-backend-dynamic
   #   disabled: false
 
-  # Quay backend (use the OCI overlay; the old ./dynamic-plugins/dist/backstage-community-plugin-quay
-  # path is not present in RHDH 1.10+ images and will fail install-dynamic-plugins with ENOENT)
-  # - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay-backend:{{inherit}}'
-  #   disabled: false
-
 # # loading plugin from host directory
 #   - package: ./local-plugins/todo
 #     disabled: false

--- a/configs/dynamic-plugins/dynamic-plugins.override.example.yaml
+++ b/configs/dynamic-plugins/dynamic-plugins.override.example.yaml
@@ -21,6 +21,11 @@ includes:
   # - package: ./dynamic-plugins/dist/backstage-community-plugin-tech-radar-backend-dynamic
   #   disabled: false
 
+  # Quay backend (use the OCI overlay; the old ./dynamic-plugins/dist/backstage-community-plugin-quay
+  # path is not present in RHDH 1.10+ images and will fail install-dynamic-plugins with ENOENT)
+  # - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay-backend:{{inherit}}'
+  #   disabled: false
+
 # # loading plugin from host directory
 #   - package: ./local-plugins/todo
 #     disabled: false

--- a/docs/rhdh-local-guide/postgresql-guide.md
+++ b/docs/rhdh-local-guide/postgresql-guide.md
@@ -86,7 +86,7 @@ To move the optional Postgres service to a newer major version of the [sclorg Po
 
 The new image must support upgrading from your current major version (its `POSTGRESQL_PREV_VERSION` must match). See [Upgrading Database](https://github.com/sclorg/postgresql-container/blob/master/src/root/usr/share/container-scripts/postgresql/README.md) for `POSTGRESQL_UPGRADE=copy` vs `hardlink` (prefer `copy`).
 
-> **Warning:** Schedule downtime. Back up the Postgres data volume (or take a host-level snapshot) before upgrading. The `copy` mode needs roughly as much free space as the current data directory.
+> **Warning:** Back up the Postgres data volume (or take a host-level snapshot) before upgrading. Stop RHDH first so nothing writes to the database during the upgrade. The `copy` mode needs roughly as much free space as the current data directory.
 
 ### Steps
 

--- a/docs/rhdh-local-guide/postgresql-guide.md
+++ b/docs/rhdh-local-guide/postgresql-guide.md
@@ -7,7 +7,7 @@ If you want to use PostgreSQL with RHDH, here are the steps:
 
 The examples below use `podman` and `podman compose`. If you use Docker, replace `podman` with `docker` (for example `docker login`, `docker compose`, `docker exec`).
 
-Set `POSTGRES_PASSWORD` in `.env` as well (Compose expands `${POSTGRES_PASSWORD}` from `.env`, not from `default.env`).
+Copy the `POSTGRES_*` values from `default.env` into your project `.env` (or ensure they are set in the environment).
 
 1. Login to container registry with *Red Hat Login* credentials to use `postgresql` image
 

--- a/docs/rhdh-local-guide/postgresql-guide.md
+++ b/docs/rhdh-local-guide/postgresql-guide.md
@@ -136,18 +136,11 @@ See [sclorg postgresql-container — Upgrading Database](https://github.com/sclo
    # podman exec db psql -U postgres -c 'ALTER DATABASE "<dbname>" REFRESH COLLATION VERSION;'
    ```
 
-6. After a successful upgrade, remove `POSTGRESQL_UPGRADE=copy` from `compose.yaml` so the upgrade does not run again on later restarts, then recreate the `db` container (so it starts without that env var):
-
-   ```yaml
-   environment:
-     - POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD}
-   ```
+6. Remove `POSTGRESQL_UPGRADE=copy` from the `db` service environment (leave `POSTGRESQL_ADMIN_PASSWORD` / `default.env` as before), then recreate the container:
 
    ```sh
    podman compose up -d --force-recreate db
    ```
-
-   `--force-recreate` replaces the existing `db` container even if Compose would otherwise keep it. The data volume is unchanged.
 
 7. Start RHDH again and verify the instance:
 

--- a/docs/rhdh-local-guide/postgresql-guide.md
+++ b/docs/rhdh-local-guide/postgresql-guide.md
@@ -114,7 +114,7 @@ The new image must support upgrading from your current major version (its `POSTG
        - POSTGRESQL_UPGRADE=copy
    ```
 
-4. Recreate and start the `db` service (keep the same data volume; do not run `compose down --volumes`):
+4. Recreate and start the `db` **container** so it boots the new image against the **existing** data volume (do not run `compose down --volumes`):
 
    ```sh
    podman compose up -d db
@@ -126,7 +126,7 @@ The new image must support upgrading from your current major version (its `POSTG
    podman exec db psql -U postgres -c "SHOW server_version;"
    ```
 
-   The first start can take a minute while `pg_upgrade` runs.
+   The first start can take a minute while `pg_upgrade` runs. Your databases and rows stay on the mounted volume under `/var/lib/pgsql/data`; only the container/image changes.
 
 5. Refresh collation versions if PostgreSQL warns about a collation mismatch (common when the image base OS changes). Run for `postgres`, `template1`, and each user database:
 
@@ -137,11 +137,13 @@ The new image must support upgrading from your current major version (its `POSTG
    # podman exec db psql -U postgres -c 'ALTER DATABASE "<dbname>" REFRESH COLLATION VERSION;'
    ```
 
-6. Remove `POSTGRESQL_UPGRADE=copy` from `compose.yaml`, then recreate `db` so the new env applies (data volume is kept):
+6. Remove `POSTGRESQL_UPGRADE=copy` from `compose.yaml`, then force-recreate only the `db` **container** so the updated environment takes effect:
 
    ```sh
    podman compose up -d --force-recreate db
    ```
+
+   `--force-recreate` replaces the container; it does **not** create a fresh database or wipe `/var/lib/pgsql/data`. Compose keeps the existing volume as long as you do not pass `--volumes` / `-v` to `down` or otherwise remove that volume.
 
 7. Start RHDH again and verify the instance:
 
@@ -153,7 +155,8 @@ The new image must support upgrading from your current major version (its `POSTG
 
 ### What not to do
 
-- Do not delete the Postgres data volume as part of this upgrade.
+- Do not delete the Postgres data volume as part of this upgrade (`compose down --volumes`, `volume rm`, pruning volumes, etc.).
+- Do not treat `--force-recreate db` as a data reset — it only recreates the container.
 - Do not leave `POSTGRESQL_UPGRADE` set after the upgrade succeeds.
 - Prefer `copy` over `hardlink` unless you understand the [sclorg hardlink trade-offs](https://github.com/sclorg/postgresql-container/blob/master/src/root/usr/share/container-scripts/postgresql/README.md).
 - Do not wipe Lightspeed/RAG or other non-Postgres compose volumes when recycling the stack.

--- a/docs/rhdh-local-guide/postgresql-guide.md
+++ b/docs/rhdh-local-guide/postgresql-guide.md
@@ -3,7 +3,7 @@
 By default, in-memory db is used.
 If you want to use PostgreSQL with RHDH, here are the steps:
 
-> **NOTE**: You must have [Red Hat Login](https://access.redhat.com/RegistryAuthentication#getting-a-red-hat-login-2) to use `postgresql` image.
+> **NOTE**: You must have [Red Hat Login](https://access.redhat.com/RegistryAuthentication#getting-a-red-hat-login-2) to use the [rhel10/postgresql-18](https://catalog.redhat.com/en/software/containers/rhel10/postgresql-18/6942a60aab9edd836017e3d0) image from `registry.redhat.io`.
 
 1. Login to container registry with *Red Hat Login* credentials to use `postgresql` image
 
@@ -21,7 +21,7 @@ If you want to use PostgreSQL with RHDH, here are the steps:
 
    ```yaml
    db:
-     image: "registry.redhat.io/rhel8/postgresql-16:latest"
+     image: "registry.redhat.io/rhel10/postgresql-18:latest"
      volumes:
        - "/var/lib/pgsql/data"
      env_file:
@@ -48,7 +48,7 @@ If you want to use PostgreSQL with RHDH, here are the steps:
        condition: service_healthy
    ```
 
-4. Comment out the SQLite in-memory configuration in [`app-config.local.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/configs/app-config/app-config.local.example.yaml)
+4. Comment out the SQLite in-memory configuration in [`app-config.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/configs/app-config/app-config.yaml) (or override it from `app-config.local.yaml`)
 
    ```yaml
    # database:
@@ -81,3 +81,89 @@ If you want to use PostgreSQL with RHDH, here are the steps:
          user: ${POSTGRES_USER}
          password: ${POSTGRES_PASSWORD}
    ```
+
+## Upgrading PostgreSQL 16 to 18
+
+If you already run the optional Postgres service on **`registry.redhat.io/rhel8/postgresql-16`** and want to move to **`registry.redhat.io/rhel10/postgresql-18`**, use the image’s built-in major upgrade (`pg_upgrade`) by setting `POSTGRESQL_UPGRADE=copy` for a single boot. This keeps the existing data volume; do not delete the Postgres data directory for this path.
+
+Background and details (do not restate the full procedures here):
+
+- [sclorg postgresql-container — Upgrading Database](https://github.com/sclorg/postgresql-container/blob/master/src/root/usr/share/container-scripts/postgresql/README.md) (`POSTGRESQL_UPGRADE=copy` or `hardlink`; prefer **`copy`**, and ensure enough free disk for a full data copy)
+- [PostgreSQL — Upgrading a PostgreSQL Cluster](https://www.postgresql.org/docs/current/upgrading.html) (general major-upgrade background; rhdh-local uses the container `POSTGRESQL_UPGRADE` / `pg_upgrade` path, not a manual `pg_dumpall` flow)
+- Images: [rhel8/postgresql-16](https://catalog.redhat.com/en/software/containers/rhel8/postgresql-16/657c148efd40a94aa696f28e) → [rhel10/postgresql-18](https://catalog.redhat.com/en/software/containers/rhel10/postgresql-18/6942a60aab9edd836017e3d0)
+
+> **Warning:** Schedule downtime. Back up the Postgres data volume (or take a host-level snapshot) before upgrading. The `copy` mode needs roughly as much free space as the current data directory.
+
+### Steps
+
+1. Confirm you are on PostgreSQL 16 and note the version:
+
+   ```sh
+   podman exec db psql -U postgres -c "SHOW server_version;"
+   ```
+
+   Expect a `16.x` result. If you use `docker`, replace `podman` with `docker` in these commands.
+
+2. Stop RHDH so it does not write during the upgrade:
+
+   ```sh
+   podman compose stop rhdh
+   ```
+
+3. In `compose.yaml`, change the `db` service image to PostgreSQL 18 and add `POSTGRESQL_UPGRADE=copy` for this boot only:
+
+   ```yaml
+   db:
+     image: "registry.redhat.io/rhel10/postgresql-18:latest"
+     # ...existing volumes, env_file, healthcheck...
+     environment:
+       - POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD}
+       - POSTGRESQL_UPGRADE=copy
+   ```
+
+4. Recreate and start the `db` service (keep the same data volume; do not run `compose down --volumes`):
+
+   ```sh
+   podman compose up -d db
+   ```
+
+   Wait until the container is healthy, then confirm the major version is 18:
+
+   ```sh
+   podman exec db psql -U postgres -c "SHOW server_version;"
+   ```
+
+5. After a successful upgrade, **remove** `POSTGRESQL_UPGRADE=copy` from `compose.yaml` so the upgrade does not run again on later restarts, then recreate `db`:
+
+   ```yaml
+   environment:
+     - POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD}
+   ```
+
+   ```sh
+   podman compose up -d --force-recreate db
+   ```
+
+6. Refresh collation versions if PostgreSQL warns about a collation mismatch (common when moving from an older RHEL base to rhel10). Run for `postgres`, `template1`, and each user database:
+
+   ```sh
+   podman exec db psql -U postgres -c 'ALTER DATABASE postgres REFRESH COLLATION VERSION;'
+   podman exec db psql -U postgres -c 'ALTER DATABASE template1 REFRESH COLLATION VERSION;'
+   # Repeat for each application database, for example:
+   # podman exec db psql -U postgres -c 'ALTER DATABASE "<dbname>" REFRESH COLLATION VERSION;'
+   ```
+
+7. Start RHDH again and verify the instance:
+
+   ```sh
+   podman compose up -d rhdh
+   ```
+
+   Open [http://localhost:7007](http://localhost:7007) and confirm your catalog (or other persisted data) is still present.
+
+### What not to do
+
+- Do not delete the Postgres data volume as part of this upgrade.
+- Do not leave `POSTGRESQL_UPGRADE` set after the upgrade succeeds.
+- Prefer `copy` over `hardlink` unless you understand the [sclorg hardlink trade-offs](https://github.com/sclorg/postgresql-container/blob/master/src/root/usr/share/container-scripts/postgresql/README.md).
+- Do not wipe Lightspeed/RAG or other non-Postgres compose volumes when recycling the stack.

--- a/docs/rhdh-local-guide/postgresql-guide.md
+++ b/docs/rhdh-local-guide/postgresql-guide.md
@@ -26,7 +26,7 @@ The examples below use `podman` and `podman compose`. If you use Docker, replace
        - path: "./.env"
          required: false
      environment:
-       - POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD}
+       - POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD:-postgres}
      healthcheck:
        test: ["CMD", "pg_isready", "-U", "postgres"]
        interval: 5s
@@ -109,7 +109,7 @@ See [sclorg postgresql-container — Upgrading Database](https://github.com/sclo
      image: "registry.redhat.io/rhel10/postgresql-18:latest"
      # ...existing volumes, env_file, healthcheck...
      environment:
-       - POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD}
+       - POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD:-postgres}
        - POSTGRESQL_UPGRADE=copy
    ```
 
@@ -136,7 +136,7 @@ See [sclorg postgresql-container — Upgrading Database](https://github.com/sclo
    # podman exec db psql -U postgres -c 'ALTER DATABASE "<dbname>" REFRESH COLLATION VERSION;'
    ```
 
-6. Remove `POSTGRESQL_UPGRADE=copy` from the `db` service environment (leave `POSTGRESQL_ADMIN_PASSWORD` / `default.env` as before), then recreate the container:
+6. Remove `POSTGRESQL_UPGRADE=copy` from `compose.yaml`, then recreate `db` so the container no longer has that env var (data volume is kept):
 
    ```sh
    podman compose up -d --force-recreate db

--- a/docs/rhdh-local-guide/postgresql-guide.md
+++ b/docs/rhdh-local-guide/postgresql-guide.md
@@ -13,8 +13,6 @@ The examples below use `podman` and `podman compose`. If you use Docker, replace
    podman login registry.redhat.io
    ```
 
-   Also put `POSTGRES_PASSWORD` in the project `.env` file (for example `POSTGRES_PASSWORD=postgres`). Compose substitutes that value into `POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD}` in `compose.yaml`. Having the password only in `default.env` is not enough for that substitution.
-
 2. Uncomment the `db` service block in [https://github.com/redhat-developer/rhdh-local/blob/main/compose.yaml](https://github.com/redhat-developer/rhdh-local/blob/main/compose.yaml) file
 
    ```yaml
@@ -82,17 +80,11 @@ The examples below use `podman` and `podman compose`. If you use Docker, replace
 
 ## Upgrading PostgreSQL 16 to 18
 
-If you already run the optional Postgres service on `registry.redhat.io/rhel8/postgresql-16` and want to move to `registry.redhat.io/rhel10/postgresql-18`, use the image’s built-in major upgrade (`pg_upgrade`) by setting `POSTGRESQL_UPGRADE=copy` for a single boot. This keeps the existing data volume; do not delete the Postgres data directory for this path.
+If you already run the optional Postgres service on [`rhel8/postgresql-16`](https://catalog.redhat.com/en/software/containers/rhel8/postgresql-16/657c148efd40a94aa696f28e) and want to move to [`rhel10/postgresql-18`](https://catalog.redhat.com/en/software/containers/rhel10/postgresql-18/6942a60aab9edd836017e3d0), use the image’s built-in upgrade by setting `POSTGRESQL_UPGRADE=copy` for a single boot. That runs `pg_upgrade` inside the container and keeps the existing data volume; do not delete the Postgres data directory for this path.
 
-Background and details (do not restate the full procedures here):
-
-- [sclorg postgresql-container — Upgrading Database](https://github.com/sclorg/postgresql-container/blob/master/src/root/usr/share/container-scripts/postgresql/README.md) (`POSTGRESQL_UPGRADE=copy` or `hardlink`; prefer `copy`, and ensure enough free disk for a full data copy)
-- [PostgreSQL — Upgrading a PostgreSQL Cluster](https://www.postgresql.org/docs/current/upgrading.html) (general major-upgrade background; rhdh-local uses the container `POSTGRESQL_UPGRADE` / `pg_upgrade` path, not a manual `pg_dumpall` flow)
-- Images: [rhel8/postgresql-16](https://catalog.redhat.com/en/software/containers/rhel8/postgresql-16/657c148efd40a94aa696f28e) → [rhel10/postgresql-18](https://catalog.redhat.com/en/software/containers/rhel10/postgresql-18/6942a60aab9edd836017e3d0)
+See [sclorg postgresql-container — Upgrading Database](https://github.com/sclorg/postgresql-container/blob/master/src/root/usr/share/container-scripts/postgresql/README.md) for `POSTGRESQL_UPGRADE=copy` vs `hardlink` (prefer `copy`).
 
 > **Warning:** Schedule downtime. Back up the Postgres data volume (or take a host-level snapshot) before upgrading. The `copy` mode needs roughly as much free space as the current data directory.
-
-The examples use `podman` / `podman compose`. With Docker, replace `podman` with `docker` the same way as in the enablement steps above. The compose service and container name is `db`.
 
 ### Steps
 
@@ -144,7 +136,7 @@ The examples use `podman` / `podman compose`. With Docker, replace `podman` with
    # podman exec db psql -U postgres -c 'ALTER DATABASE "<dbname>" REFRESH COLLATION VERSION;'
    ```
 
-6. After a successful upgrade, remove `POSTGRESQL_UPGRADE=copy` from `compose.yaml` so the upgrade does not run again on later restarts, then recreate `db`:
+6. After a successful upgrade, remove `POSTGRESQL_UPGRADE=copy` from `compose.yaml` so the upgrade does not run again on later restarts, then recreate the `db` container (so it starts without that env var):
 
    ```yaml
    environment:
@@ -154,6 +146,8 @@ The examples use `podman` / `podman compose`. With Docker, replace `podman` with
    ```sh
    podman compose up -d --force-recreate db
    ```
+
+   `--force-recreate` replaces the existing `db` container even if Compose would otherwise keep it. The data volume is unchanged.
 
 7. Start RHDH again and verify the instance:
 

--- a/docs/rhdh-local-guide/postgresql-guide.md
+++ b/docs/rhdh-local-guide/postgresql-guide.md
@@ -7,7 +7,7 @@ If you want to use PostgreSQL with RHDH, here are the steps:
 
 The examples below use `podman` and `podman compose`. If you use Docker, replace `podman` with `docker` (for example `docker login`, `docker compose`, `docker exec`).
 
-`POSTGRES_PASSWORD` is defined in `default.env`. Also set it in your project `.env` (for example `POSTGRES_PASSWORD=postgres`) so Compose can substitute `${POSTGRES_PASSWORD}` in `compose.yaml`.
+Set `POSTGRES_PASSWORD` in `.env` as well (Compose expands `${POSTGRES_PASSWORD}` from `.env`, not from `default.env`).
 
 1. Login to container registry with *Red Hat Login* credentials to use `postgresql` image
 

--- a/docs/rhdh-local-guide/postgresql-guide.md
+++ b/docs/rhdh-local-guide/postgresql-guide.md
@@ -3,7 +3,7 @@
 By default, in-memory db is used.
 If you want to use PostgreSQL with RHDH, here are the steps:
 
-> **NOTE**: You must have [Red Hat Login](https://access.redhat.com/RegistryAuthentication#getting-a-red-hat-login-2) to use the [rhel10/postgresql-18](https://catalog.redhat.com/en/software/containers/rhel10/postgresql-18/6942a60aab9edd836017e3d0) image from `registry.redhat.io`.
+> **NOTE**: You must have [Red Hat Login](https://access.redhat.com/RegistryAuthentication#getting-a-red-hat-login-2) to use the PostgreSQL image from `registry.redhat.io` (for example [rhel10/postgresql-18](https://catalog.redhat.com/en/software/containers/rhel10/postgresql-18/6942a60aab9edd836017e3d0)).
 
 The examples below use `podman` and `podman compose`. If you use Docker, replace `podman` with `docker` (for example `docker login`, `docker compose`, `docker exec`).
 
@@ -80,23 +80,22 @@ The examples below use `podman` and `podman compose`. If you use Docker, replace
          password: ${POSTGRES_PASSWORD}
    ```
 
-## Upgrading PostgreSQL 16 to 18
+## Upgrading PostgreSQL
 
-If you already run the optional Postgres service on [`rhel8/postgresql-16`](https://catalog.redhat.com/en/software/containers/rhel8/postgresql-16/657c148efd40a94aa696f28e) and want to move to [`rhel10/postgresql-18`](https://catalog.redhat.com/en/software/containers/rhel10/postgresql-18/6942a60aab9edd836017e3d0), use the image’s built-in upgrade by setting `POSTGRESQL_UPGRADE=copy` for a single boot. That runs `pg_upgrade` inside the container and keeps the existing data volume; do not delete the Postgres data directory for this path.
+To move the optional Postgres service to a newer major version of the [sclorg PostgreSQL container](https://github.com/sclorg/postgresql-container), use the image’s built-in upgrade by setting `POSTGRESQL_UPGRADE=copy` for a single boot. That runs `pg_upgrade` inside the container and keeps the existing data volume; do not delete the Postgres data directory for this path.
 
-See [sclorg postgresql-container — Upgrading Database](https://github.com/sclorg/postgresql-container/blob/master/src/root/usr/share/container-scripts/postgresql/README.md) for `POSTGRESQL_UPGRADE=copy` vs `hardlink` (prefer `copy`).
+The new image must support upgrading from your current major version (its `POSTGRESQL_PREV_VERSION` must match). See [Upgrading Database](https://github.com/sclorg/postgresql-container/blob/master/src/root/usr/share/container-scripts/postgresql/README.md) for `POSTGRESQL_UPGRADE=copy` vs `hardlink` (prefer `copy`).
 
 > **Warning:** Schedule downtime. Back up the Postgres data volume (or take a host-level snapshot) before upgrading. The `copy` mode needs roughly as much free space as the current data directory.
 
 ### Steps
 
-1. Confirm you are on PostgreSQL 16 and note the version:
+1. Note your current Postgres version and image:
 
    ```sh
    podman exec db psql -U postgres -c "SHOW server_version;"
+   podman inspect db --format '{{.Config.Image}}'
    ```
-
-   Expect a `16.x` result.
 
 2. Stop RHDH so it does not write during the upgrade:
 
@@ -104,11 +103,11 @@ See [sclorg postgresql-container — Upgrading Database](https://github.com/sclo
    podman compose stop rhdh
    ```
 
-3. In `compose.yaml`, change the `db` service image to PostgreSQL 18 and add `POSTGRESQL_UPGRADE=copy` for this boot only:
+3. In `compose.yaml`, set `db.image` to the newer Postgres image and add `POSTGRESQL_UPGRADE=copy` for this boot only:
 
    ```yaml
    db:
-     image: "registry.redhat.io/rhel10/postgresql-18:latest"
+     image: "registry.redhat.io/<newer-postgresql-image>:latest"
      # ...existing volumes, env_file, healthcheck...
      environment:
        - POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD}
@@ -121,15 +120,15 @@ See [sclorg postgresql-container — Upgrading Database](https://github.com/sclo
    podman compose up -d db
    ```
 
-   Wait until `db` is healthy (`podman compose ps`), then confirm the major version is 18:
+   Wait until `db` is healthy (`podman compose ps`), then confirm the new major version:
 
    ```sh
    podman exec db psql -U postgres -c "SHOW server_version;"
    ```
 
-   Expect a `18.x` result. The first start can take a minute while `pg_upgrade` runs.
+   The first start can take a minute while `pg_upgrade` runs.
 
-5. Refresh collation versions if PostgreSQL warns about a collation mismatch (common when moving from an older RHEL base to rhel10). Run for `postgres`, `template1`, and each user database:
+5. Refresh collation versions if PostgreSQL warns about a collation mismatch (common when the image base OS changes). Run for `postgres`, `template1`, and each user database:
 
    ```sh
    podman exec db psql -U postgres -c 'ALTER DATABASE postgres REFRESH COLLATION VERSION;'
@@ -158,3 +157,4 @@ See [sclorg postgresql-container — Upgrading Database](https://github.com/sclo
 - Do not leave `POSTGRESQL_UPGRADE` set after the upgrade succeeds.
 - Prefer `copy` over `hardlink` unless you understand the [sclorg hardlink trade-offs](https://github.com/sclorg/postgresql-container/blob/master/src/root/usr/share/container-scripts/postgresql/README.md).
 - Do not wipe Lightspeed/RAG or other non-Postgres compose volumes when recycling the stack.
+- Do not skip a major version unless the target image documents that hop (`POSTGRESQL_PREV_VERSION`).

--- a/docs/rhdh-local-guide/postgresql-guide.md
+++ b/docs/rhdh-local-guide/postgresql-guide.md
@@ -5,16 +5,12 @@ If you want to use PostgreSQL with RHDH, here are the steps:
 
 > **NOTE**: You must have [Red Hat Login](https://access.redhat.com/RegistryAuthentication#getting-a-red-hat-login-2) to use the [rhel10/postgresql-18](https://catalog.redhat.com/en/software/containers/rhel10/postgresql-18/6942a60aab9edd836017e3d0) image from `registry.redhat.io`.
 
+The examples below use `podman` and `podman compose`. If you use Docker, replace `podman` with `docker` (for example `docker login`, `docker compose`, `docker exec`).
+
 1. Login to container registry with *Red Hat Login* credentials to use `postgresql` image
 
    ```sh
    podman login registry.redhat.io
-   ```
-
-   If you prefer `docker` you can just replace `podman` with `docker`
-
-   ```sh
-   docker login registry.redhat.io
    ```
 
 2. Uncomment the `db` service block in [https://github.com/redhat-developer/rhdh-local/blob/main/compose.yaml](https://github.com/redhat-developer/rhdh-local/blob/main/compose.yaml) file
@@ -48,7 +44,7 @@ If you want to use PostgreSQL with RHDH, here are the steps:
        condition: service_healthy
    ```
 
-4. Comment out the SQLite in-memory configuration in [`app-config.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/configs/app-config/app-config.yaml) (or override it from `app-config.local.yaml`)
+4. Comment out the SQLite in-memory configuration in [`app-config.local.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/configs/app-config/app-config.local.example.yaml)
 
    ```yaml
    # database:
@@ -68,7 +64,7 @@ If you want to use PostgreSQL with RHDH, here are the steps:
       password: ${POSTGRES_PASSWORD}
    ```
 
-   If you need **`pluginDivisionMode: schema`** (one database, one schema per plugin — useful when the DB user cannot create multiple databases), use this **`backend.database`** block in `app-config.local.yaml` **instead** of the snippet above:
+   If you need `pluginDivisionMode: schema` (one database, one schema per plugin — useful when the DB user cannot create multiple databases), use this `backend.database` block in `app-config.local.yaml` instead of the snippet above:
 
    ```yaml
    backend:
@@ -84,15 +80,17 @@ If you want to use PostgreSQL with RHDH, here are the steps:
 
 ## Upgrading PostgreSQL 16 to 18
 
-If you already run the optional Postgres service on **`registry.redhat.io/rhel8/postgresql-16`** and want to move to **`registry.redhat.io/rhel10/postgresql-18`**, use the image’s built-in major upgrade (`pg_upgrade`) by setting `POSTGRESQL_UPGRADE=copy` for a single boot. This keeps the existing data volume; do not delete the Postgres data directory for this path.
+If you already run the optional Postgres service on `registry.redhat.io/rhel8/postgresql-16` and want to move to `registry.redhat.io/rhel10/postgresql-18`, use the image’s built-in major upgrade (`pg_upgrade`) by setting `POSTGRESQL_UPGRADE=copy` for a single boot. This keeps the existing data volume; do not delete the Postgres data directory for this path.
 
 Background and details (do not restate the full procedures here):
 
-- [sclorg postgresql-container — Upgrading Database](https://github.com/sclorg/postgresql-container/blob/master/src/root/usr/share/container-scripts/postgresql/README.md) (`POSTGRESQL_UPGRADE=copy` or `hardlink`; prefer **`copy`**, and ensure enough free disk for a full data copy)
+- [sclorg postgresql-container — Upgrading Database](https://github.com/sclorg/postgresql-container/blob/master/src/root/usr/share/container-scripts/postgresql/README.md) (`POSTGRESQL_UPGRADE=copy` or `hardlink`; prefer `copy`, and ensure enough free disk for a full data copy)
 - [PostgreSQL — Upgrading a PostgreSQL Cluster](https://www.postgresql.org/docs/current/upgrading.html) (general major-upgrade background; rhdh-local uses the container `POSTGRESQL_UPGRADE` / `pg_upgrade` path, not a manual `pg_dumpall` flow)
 - Images: [rhel8/postgresql-16](https://catalog.redhat.com/en/software/containers/rhel8/postgresql-16/657c148efd40a94aa696f28e) → [rhel10/postgresql-18](https://catalog.redhat.com/en/software/containers/rhel10/postgresql-18/6942a60aab9edd836017e3d0)
 
 > **Warning:** Schedule downtime. Back up the Postgres data volume (or take a host-level snapshot) before upgrading. The `copy` mode needs roughly as much free space as the current data directory.
+
+The examples use `podman` / `podman compose`. With Docker, replace `podman` with `docker` the same way as in the enablement steps above. The compose service and container name is `db`.
 
 ### Steps
 
@@ -102,7 +100,7 @@ Background and details (do not restate the full procedures here):
    podman exec db psql -U postgres -c "SHOW server_version;"
    ```
 
-   Expect a `16.x` result. If you use `docker`, replace `podman` with `docker` in these commands.
+   Expect a `16.x` result.
 
 2. Stop RHDH so it does not write during the upgrade:
 
@@ -133,7 +131,7 @@ Background and details (do not restate the full procedures here):
    podman exec db psql -U postgres -c "SHOW server_version;"
    ```
 
-5. After a successful upgrade, **remove** `POSTGRESQL_UPGRADE=copy` from `compose.yaml` so the upgrade does not run again on later restarts, then recreate `db`:
+5. After a successful upgrade, remove `POSTGRESQL_UPGRADE=copy` from `compose.yaml` so the upgrade does not run again on later restarts, then recreate `db`:
 
    ```yaml
    environment:

--- a/docs/rhdh-local-guide/postgresql-guide.md
+++ b/docs/rhdh-local-guide/postgresql-guide.md
@@ -7,6 +7,8 @@ If you want to use PostgreSQL with RHDH, here are the steps:
 
 The examples below use `podman` and `podman compose`. If you use Docker, replace `podman` with `docker` (for example `docker login`, `docker compose`, `docker exec`).
 
+`POSTGRES_PASSWORD` is defined in `default.env`. Also set it in your project `.env` (for example `POSTGRES_PASSWORD=postgres`) so Compose can substitute `${POSTGRES_PASSWORD}` in `compose.yaml`.
+
 1. Login to container registry with *Red Hat Login* credentials to use `postgresql` image
 
    ```sh
@@ -26,7 +28,7 @@ The examples below use `podman` and `podman compose`. If you use Docker, replace
        - path: "./.env"
          required: false
      environment:
-       - POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD:-postgres}
+       - POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD}
      healthcheck:
        test: ["CMD", "pg_isready", "-U", "postgres"]
        interval: 5s
@@ -109,7 +111,7 @@ See [sclorg postgresql-container — Upgrading Database](https://github.com/sclo
      image: "registry.redhat.io/rhel10/postgresql-18:latest"
      # ...existing volumes, env_file, healthcheck...
      environment:
-       - POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD:-postgres}
+       - POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD}
        - POSTGRESQL_UPGRADE=copy
    ```
 
@@ -136,7 +138,7 @@ See [sclorg postgresql-container — Upgrading Database](https://github.com/sclo
    # podman exec db psql -U postgres -c 'ALTER DATABASE "<dbname>" REFRESH COLLATION VERSION;'
    ```
 
-6. Remove `POSTGRESQL_UPGRADE=copy` from `compose.yaml`, then recreate `db` so the container no longer has that env var (data volume is kept):
+6. Remove `POSTGRESQL_UPGRADE=copy` from `compose.yaml`, then recreate `db` so the new env applies (data volume is kept):
 
    ```sh
    podman compose up -d --force-recreate db

--- a/docs/rhdh-local-guide/postgresql-guide.md
+++ b/docs/rhdh-local-guide/postgresql-guide.md
@@ -13,6 +13,8 @@ The examples below use `podman` and `podman compose`. If you use Docker, replace
    podman login registry.redhat.io
    ```
 
+   Also put `POSTGRES_PASSWORD` in the project `.env` file (for example `POSTGRES_PASSWORD=postgres`). Compose substitutes that value into `POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD}` in `compose.yaml`. Having the password only in `default.env` is not enough for that substitution.
+
 2. Uncomment the `db` service block in [https://github.com/redhat-developer/rhdh-local/blob/main/compose.yaml](https://github.com/redhat-developer/rhdh-local/blob/main/compose.yaml) file
 
    ```yaml
@@ -125,13 +127,24 @@ The examples use `podman` / `podman compose`. With Docker, replace `podman` with
    podman compose up -d db
    ```
 
-   Wait until the container is healthy, then confirm the major version is 18:
+   Wait until `db` is healthy (`podman compose ps`), then confirm the major version is 18:
 
    ```sh
    podman exec db psql -U postgres -c "SHOW server_version;"
    ```
 
-5. After a successful upgrade, remove `POSTGRESQL_UPGRADE=copy` from `compose.yaml` so the upgrade does not run again on later restarts, then recreate `db`:
+   Expect a `18.x` result. The first start can take a minute while `pg_upgrade` runs.
+
+5. Refresh collation versions if PostgreSQL warns about a collation mismatch (common when moving from an older RHEL base to rhel10). Run for `postgres`, `template1`, and each user database:
+
+   ```sh
+   podman exec db psql -U postgres -c 'ALTER DATABASE postgres REFRESH COLLATION VERSION;'
+   podman exec db psql -U postgres -c 'ALTER DATABASE template1 REFRESH COLLATION VERSION;'
+   # Repeat for each application database, for example:
+   # podman exec db psql -U postgres -c 'ALTER DATABASE "<dbname>" REFRESH COLLATION VERSION;'
+   ```
+
+6. After a successful upgrade, remove `POSTGRESQL_UPGRADE=copy` from `compose.yaml` so the upgrade does not run again on later restarts, then recreate `db`:
 
    ```yaml
    environment:
@@ -140,15 +153,6 @@ The examples use `podman` / `podman compose`. With Docker, replace `podman` with
 
    ```sh
    podman compose up -d --force-recreate db
-   ```
-
-6. Refresh collation versions if PostgreSQL warns about a collation mismatch (common when moving from an older RHEL base to rhel10). Run for `postgres`, `template1`, and each user database:
-
-   ```sh
-   podman exec db psql -U postgres -c 'ALTER DATABASE postgres REFRESH COLLATION VERSION;'
-   podman exec db psql -U postgres -c 'ALTER DATABASE template1 REFRESH COLLATION VERSION;'
-   # Repeat for each application database, for example:
-   # podman exec db psql -U postgres -c 'ALTER DATABASE "<dbname>" REFRESH COLLATION VERSION;'
    ```
 
 7. Start RHDH again and verify the instance:


### PR DESCRIPTION
## Description

Align RHDH Local's optional Compose Postgres with the PG18 direction from [RHIDP-13956](https://redhat.atlassian.net/browse/RHIDP-13956):

- Bump the optional `db` image example to `registry.redhat.io/rhel10/postgresql-18`
- Document a version-neutral major-upgrade path using sclorg `POSTGRESQL_UPGRADE=copy`
- Keep in-memory SQLite as the default database

Tracked by [RHIDP-15765](https://redhat.atlassian.net/browse/RHIDP-15765) (child of RHIDP-13956). Related product docs work remains [RHIDP-14594](https://redhat.atlassian.net/browse/RHIDP-14594) (chart/operator); this PR is RHDH Local only. Procedure inspired by [rhdh#5139](https://github.com/redhat-developer/rhdh/pull/5139).

## Which issue(s) does this PR fix or relate to

- Fixes RHIDP-15765
- Epic: RHIDP-13956
- Related: RHIDP-14594

## PR acceptance criteria

- [ ] Tests updated and passing
- [x] Documentation updated
- [x] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

## How to test changes / Special notes to the reviewer

Locally verified end-to-end:

1. Start optional `db` on `rhel8/postgresql-16`, seed proof data, bring up RHDH (`:1.10`) → HTTP 200
2. Stop RHDH; switch to `rhel10/postgresql-18` with `POSTGRESQL_UPGRADE=copy` (same volume)
3. Confirm `SHOW server_version` 16.x → 18.x and proof data survives (`Upgrade Complete` in db logs)
4. Refresh collation versions if warned; remove `POSTGRESQL_UPGRADE`; `--force-recreate db`
5. Start RHDH again → HTTP 200, PostgreSQL store, restart count 0