### PR TITLE
fix: optional Postgres via compose-with-db overlay

### DIFF
--- a/.github/actions/rhdh-local-compose-test/action.yaml
+++ b/.github/actions/rhdh-local-compose-test/action.yaml
@@ -44,6 +44,14 @@ inputs:
     description: Log level to use
     required: false
     default: "info"
+  registry_redhat_io_username:
+    description: Username for registry.redhat.io (required when compose_config_name is with-db)
+    required: false
+    default: ""
+  registry_redhat_io_password:
+    description: Password or token for registry.redhat.io (required when compose_config_name is with-db)
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -179,6 +187,24 @@ runs:
       env:
         TOOL: ${{ inputs.container_tool }}
       run: $TOOL info
+
+    # Requires REGISTRY_REDHAT_IO_USERNAME / REGISTRY_REDHAT_IO_PASSWORD for with-db.
+    - name: Log in to registry.redhat.io
+      if: ${{ env.SKIP_TEST != 'true' && inputs.compose_config_name == 'with-db' }}
+      shell: bash
+      env:
+        TOOL: ${{ inputs.container_tool }}
+        REGISTRY_USER: ${{ inputs.registry_redhat_io_username }}
+        REGISTRY_PASSWORD: ${{ inputs.registry_redhat_io_password }}
+        PODMAN_CONTAINER: ${{ steps.setup-podman.outputs.container-name }}
+      run: |
+        echo "$REGISTRY_PASSWORD" | docker login registry.redhat.io -u "$REGISTRY_USER" --password-stdin
+        if [ "$TOOL" = "podman" ]; then
+          # Compose uses docker-compose inside the container, which reads Docker
+          # config there (podman login / host-only docker login are not enough).
+          docker exec "$PODMAN_CONTAINER" mkdir -p /root/.docker
+          docker cp "$HOME/.docker/config.json" "$PODMAN_CONTAINER:/root/.docker/config.json"
+        fi
 
     - name: Create .env file to override defaults
       if: ${{ env.SKIP_TEST != 'true' && inputs.override_images == 'true' }}

--- a/.github/actions/rhdh-local-compose-test/action.yaml
+++ b/.github/actions/rhdh-local-compose-test/action.yaml
@@ -44,14 +44,6 @@ inputs:
     description: Log level to use
     required: false
     default: "info"
-  registry_redhat_io_username:
-    description: Username for registry.redhat.io (required when compose_config_name is with-db)
-    required: false
-    default: ""
-  registry_redhat_io_password:
-    description: Password or token for registry.redhat.io (required when compose_config_name is with-db)
-    required: false
-    default: ""
 
 runs:
   using: "composite"
@@ -168,6 +160,7 @@ runs:
         docker-compose-version: v5.0.1
         env: |
           CORPORATE_PROXY_IMAGE=docker.io/ubuntu/squid:latest
+          POSTGRES_IMAGE=quay.io/fedora/postgresql-18:latest
 
     - name: Display container engine version
       if: ${{ env.SKIP_TEST != 'true' }}
@@ -187,24 +180,6 @@ runs:
       env:
         TOOL: ${{ inputs.container_tool }}
       run: $TOOL info
-
-    # Requires REGISTRY_REDHAT_IO_USERNAME / REGISTRY_REDHAT_IO_PASSWORD for with-db.
-    - name: Log in to registry.redhat.io
-      if: ${{ env.SKIP_TEST != 'true' && inputs.compose_config_name == 'with-db' }}
-      shell: bash
-      env:
-        TOOL: ${{ inputs.container_tool }}
-        REGISTRY_USER: ${{ inputs.registry_redhat_io_username }}
-        REGISTRY_PASSWORD: ${{ inputs.registry_redhat_io_password }}
-        PODMAN_CONTAINER: ${{ steps.setup-podman.outputs.container-name }}
-      run: |
-        echo "$REGISTRY_PASSWORD" | docker login registry.redhat.io -u "$REGISTRY_USER" --password-stdin
-        if [ "$TOOL" = "podman" ]; then
-          # Compose uses docker-compose inside the container, which reads Docker
-          # config there (podman login / host-only docker login are not enough).
-          docker exec "$PODMAN_CONTAINER" mkdir -p /root/.docker
-          docker cp "$HOME/.docker/config.json" "$PODMAN_CONTAINER:/root/.docker/config.json"
-        fi
 
     - name: Create .env file to override defaults
       if: ${{ env.SKIP_TEST != 'true' && inputs.override_images == 'true' }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -63,6 +63,10 @@ jobs:
             cliArgs: "-f compose.yaml -f compose-with-corporate-proxy.yaml"
           - name: "dynamic-plugins-root"
             cliArgs: "-f compose.yaml -f compose-dynamic-plugins-root.yaml"
+          # Requires REGISTRY_REDHAT_IO_USERNAME and REGISTRY_REDHAT_IO_PASSWORD
+          # (Red Hat registry service-account username + token).
+          - name: "with-db"
+            cliArgs: "-f compose.yaml -f compose-with-db.yaml"
           - name: "orchestrator-workflow"
             cliArgs: "-f compose.yaml -f orchestrator/compose.yaml"
           # TODO: Remove this and the exclude rules below once all supported
@@ -85,6 +89,10 @@ jobs:
             composeConfig:
               name: "dynamic-plugins-root"
               cliArgs: "-f compose.yaml -f compose-dynamic-plugins-root.yaml"
+          - os: ubuntu-24.04-arm
+            composeConfig:
+              name: "with-db"
+              cliArgs: "-f compose.yaml -f compose-with-db.yaml"
           - os: ubuntu-24.04-arm
             composeConfig:
               name: "developer-lightspeed"
@@ -126,3 +134,6 @@ jobs:
           compose_config_name: ${{ matrix.composeConfig.name }}
           user_config_enabled: ${{ matrix.userConfig }}
           override_images: "true"
+          registry_redhat_io_username: ${{ secrets.REGISTRY_REDHAT_IO_USERNAME }}
+          registry_redhat_io_password: ${{ secrets.REGISTRY_REDHAT_IO_PASSWORD }}
+

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -63,8 +63,7 @@ jobs:
             cliArgs: "-f compose.yaml -f compose-with-corporate-proxy.yaml"
           - name: "dynamic-plugins-root"
             cliArgs: "-f compose.yaml -f compose-dynamic-plugins-root.yaml"
-          # Requires REGISTRY_REDHAT_IO_USERNAME and REGISTRY_REDHAT_IO_PASSWORD
-          # (Red Hat registry service-account username + token).
+          # Default db image is on registry.redhat.io; CI overrides via POSTGRES_IMAGE.
           - name: "with-db"
             cliArgs: "-f compose.yaml -f compose-with-db.yaml"
           - name: "orchestrator-workflow"
@@ -117,6 +116,8 @@ jobs:
       DOCKER_COMPOSE_VERSION: v5.0.1
       PODMAN_IMAGE: quay.io/podman/stable:v5
       CORPORATE_PROXY_IMAGE: docker.io/ubuntu/squid:latest
+      # The default Postgres image is located on registry.redhat.io, which requires authentication.
+      POSTGRES_IMAGE: quay.io/fedora/postgresql-18:latest
       ACTIONS_RUNNER_DEBUG: ${{ vars.ACTIONS_RUNNER_DEBUG }}
 
     steps:
@@ -134,6 +135,4 @@ jobs:
           compose_config_name: ${{ matrix.composeConfig.name }}
           user_config_enabled: ${{ matrix.userConfig }}
           override_images: "true"
-          registry_redhat_io_username: ${{ secrets.REGISTRY_REDHAT_IO_USERNAME }}
-          registry_redhat_io_password: ${{ secrets.REGISTRY_REDHAT_IO_PASSWORD }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,10 @@ jobs:
             cliArgs: "-f compose.yaml -f compose-with-corporate-proxy.yaml"
           - name: "dynamic-plugins-root"
             cliArgs: "-f compose.yaml -f compose-dynamic-plugins-root.yaml"
+          # Requires REGISTRY_REDHAT_IO_USERNAME and REGISTRY_REDHAT_IO_PASSWORD
+          # (Red Hat registry service-account username + token).
+          - name: "with-db"
+            cliArgs: "-f compose.yaml -f compose-with-db.yaml"
 # TODO: re-enable this test once we can use the right references.
 # Tracked in https://redhat.atlassian.net/browse/RHDHBUGS-3559
 #          - name: "orchestrator-workflow"
@@ -69,3 +73,5 @@ jobs:
           compose_cli_args: ${{ matrix.composeConfig.cliArgs }}
           compose_config_name: ${{ matrix.composeConfig.name }}
           user_config_enabled: ${{ matrix.userConfig }}
+          registry_redhat_io_username: ${{ secrets.REGISTRY_REDHAT_IO_USERNAME }}
+          registry_redhat_io_password: ${{ secrets.REGISTRY_REDHAT_IO_PASSWORD }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,8 +46,7 @@ jobs:
             cliArgs: "-f compose.yaml -f compose-with-corporate-proxy.yaml"
           - name: "dynamic-plugins-root"
             cliArgs: "-f compose.yaml -f compose-dynamic-plugins-root.yaml"
-          # Requires REGISTRY_REDHAT_IO_USERNAME and REGISTRY_REDHAT_IO_PASSWORD
-          # (Red Hat registry service-account username + token).
+          # Default db image is on registry.redhat.io; CI overrides via POSTGRES_IMAGE.
           - name: "with-db"
             cliArgs: "-f compose.yaml -f compose-with-db.yaml"
 # TODO: re-enable this test once we can use the right references.
@@ -62,6 +61,8 @@ jobs:
       PODMAN_IMAGE: quay.io/podman/stable:v5
       # The default corporate proxy image is located on registry.redhat.io, which requires authentication.
       CORPORATE_PROXY_IMAGE: docker.io/ubuntu/squid:latest
+      # The default Postgres image is located on registry.redhat.io, which requires authentication.
+      POSTGRES_IMAGE: quay.io/fedora/postgresql-18:latest
 
     steps:
       # Checkout default branch so .github/actions/* exists (release-* push may not include the composite).
@@ -73,5 +74,3 @@ jobs:
           compose_cli_args: ${{ matrix.composeConfig.cliArgs }}
           compose_config_name: ${{ matrix.composeConfig.name }}
           user_config_enabled: ${{ matrix.userConfig }}
-          registry_redhat_io_username: ${{ secrets.REGISTRY_REDHAT_IO_USERNAME }}
-          registry_redhat_io_password: ${{ secrets.REGISTRY_REDHAT_IO_PASSWORD }}

--- a/compose-with-db.yaml
+++ b/compose-with-db.yaml
@@ -19,7 +19,7 @@ services:
       - path: "./.env"
         required: false
     environment:
-      - POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD:-postgres}
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "postgres"]
       interval: 5s

--- a/compose-with-db.yaml
+++ b/compose-with-db.yaml
@@ -10,7 +10,7 @@
 services:
   db:
     container_name: db
-    image: "registry.redhat.io/rhel10/postgresql-18:latest" # dclint disable-line service-image-require-explicit-tag
+    image: "${POSTGRES_IMAGE:-registry.redhat.io/rhel10/postgresql-18:latest}" # dclint disable-line service-image-require-explicit-tag
     volumes:
       - "/var/lib/pgsql/data"
     env_file:

--- a/compose-with-db.yaml
+++ b/compose-with-db.yaml
@@ -1,0 +1,32 @@
+# This Compose file is not usable on its own.
+# It needs to be used alongside the default compose.yaml file,
+# since it adds a PostgreSQL db service and makes rhdh wait for it.
+#
+# You can run `[podman|docker] compose -f compose.yaml -f compose-with-db.yaml config`
+# to view the effective merged config.
+#
+# Also configure app-config.local.yaml for Postgres (see docs/rhdh-local-guide/postgresql-guide.md).
+
+services:
+  db:
+    container_name: db
+    image: "registry.redhat.io/rhel10/postgresql-18:latest" # dclint disable-line service-image-require-explicit-tag
+    volumes:
+      - "/var/lib/pgsql/data"
+    env_file:
+      - path: "./default.env"
+        required: true
+      - path: "./.env"
+        required: false
+    environment:
+      - POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD}
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  rhdh:
+    depends_on:
+      db:
+        condition: service_healthy

--- a/compose-with-db.yaml
+++ b/compose-with-db.yaml
@@ -5,9 +5,9 @@
 # You can run `[podman|docker] compose -f compose.yaml -f compose-with-db.yaml config`
 # to view the effective merged config.
 #
-# Postgres app-config is applied automatically when this overlay is used
-# (see docs/rhdh-local-guide/postgresql-guide.md). Optional overrides still go
-# in app-config.local.yaml.
+# Postgres app-config (configs/app-config/app-config.db.yaml) is loaded when
+# this overlay is used (see docs/rhdh-local-guide/postgresql-guide.md).
+# Optional overrides still go in app-config.local.yaml.
 
 services:
   db:

--- a/compose-with-db.yaml
+++ b/compose-with-db.yaml
@@ -5,7 +5,9 @@
 # You can run `[podman|docker] compose -f compose.yaml -f compose-with-db.yaml config`
 # to view the effective merged config.
 #
-# Also configure app-config.local.yaml for Postgres (see docs/rhdh-local-guide/postgresql-guide.md).
+# Postgres app-config is applied automatically when this overlay is used
+# (see docs/rhdh-local-guide/postgresql-guide.md). Optional overrides still go
+# in app-config.local.yaml.
 
 services:
   db:
@@ -27,6 +29,8 @@ services:
       retries: 5
 
   rhdh:
+    environment:
+      WITH_POSTGRES: "true"
     depends_on:
       db:
         condition: service_healthy

--- a/compose.postgres-upgrade.override.example.yaml
+++ b/compose.postgres-upgrade.override.example.yaml
@@ -1,0 +1,18 @@
+# Temporary override for a PostgreSQL major upgrade.
+# 1. Set POSTGRES_IMAGE in .env to the target major image (must support your
+#    current major via POSTGRESQL_PREV_VERSION).
+# 2. Copy this file to compose.override.yaml for a single upgrade boot.
+# 3. After upgrade succeeds, remove POSTGRESQL_UPGRADE (delete compose.override.yaml
+#    or strip that env) and recreate db.
+#
+# When using -f compose-with-db.yaml, Compose does not auto-load
+# compose.override.yaml — include it explicitly:
+#   podman compose -f compose.yaml -f compose-with-db.yaml -f compose.override.yaml up -d db
+#
+# See docs/rhdh-local-guide/postgresql-guide.md.
+
+services:
+  db:
+    environment:
+      - POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRESQL_UPGRADE=copy

--- a/compose.postgres-upgrade.override.example.yaml
+++ b/compose.postgres-upgrade.override.example.yaml
@@ -14,5 +14,5 @@
 services:
   db:
     environment:
-      - POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD:-postgres}
       - POSTGRESQL_UPGRADE=copy

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,25 +1,6 @@
 services:
-  # Uncomment the following block to use a PostgreSQL database
-  # don't forget to also uncomment 'depends_on' 'db' section in the rhdh service
-  # and comment out or delete 'database' section in app-config.yaml or app-config.local.yaml
-
-  # db:
-  #   container_name: db
-  #   image: "registry.redhat.io/rhel10/postgresql-18:latest"
-  #   volumes:
-  #     - "/var/lib/pgsql/data"
-  #   env_file:
-  #     - path: "./default.env"
-  #       required: true
-  #     - path: "./.env"
-  #       required: false
-  #   environment:
-  #     - POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD}
-  #   healthcheck:
-  #     test: ["CMD", "pg_isready", "-U", "postgres"]
-  #     interval: 5s
-  #     timeout: 5s
-  #     retries: 5
+  # Optional PostgreSQL: merge compose-with-db.yaml (see docs/rhdh-local-guide/postgresql-guide.md)
+  # Example: podman compose -f compose.yaml -f compose-with-db.yaml up -d
 
   rhdh:
     container_name: rhdh
@@ -50,8 +31,6 @@ services:
     depends_on:
       install-dynamic-plugins:
         condition: service_completed_successfully
-      # db:
-      #   condition: service_healthy
 
   install-dynamic-plugins:
     container_name: rhdh-plugins-installer

--- a/configs/app-config/app-config.db.yaml
+++ b/configs/app-config/app-config.db.yaml
@@ -1,0 +1,11 @@
+# Loaded only when compose-with-db.yaml sets WITH_POSTGRES=true on the rhdh
+# service. This is not app-config.local.yaml — put user overrides there instead.
+
+backend:
+  database:
+    client: pg
+    connection:
+      host: ${POSTGRES_HOST}
+      port: ${POSTGRES_PORT}
+      user: ${POSTGRES_USER}
+      password: ${POSTGRES_PASSWORD}

--- a/default.env
+++ b/default.env
@@ -4,6 +4,8 @@ POSTGRES_HOST=db
 POSTGRES_PORT=5432
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
+# Optional Postgres image for compose-with-db.yaml (default: registry.redhat.io/rhel10/postgresql-18:latest)
+# POSTGRES_IMAGE=registry.redhat.io/rhel10/postgresql-18:latest
 
 BASE_URL=http://localhost:7007
 

--- a/default.env
+++ b/default.env
@@ -4,7 +4,7 @@ POSTGRES_HOST=db
 POSTGRES_PORT=5432
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
-# Optional Postgres image for compose-with-db.yaml (default: registry.redhat.io/rhel10/postgresql-18:latest)
+# To pin the image used by compose-with-db.yaml, set POSTGRES_IMAGE in .env (or export it), e.g.:
 # POSTGRES_IMAGE=registry.redhat.io/rhel10/postgresql-18:latest
 
 BASE_URL=http://localhost:7007

--- a/docs/rhdh-local-guide/postgresql-guide.md
+++ b/docs/rhdh-local-guide/postgresql-guide.md
@@ -17,38 +17,33 @@ The examples below use `podman` and `podman compose`. If you use Docker, replace
    podman login registry.redhat.io
    ```
 
-2. Uncomment the `db` service block in [https://github.com/redhat-developer/rhdh-local/blob/main/compose.yaml](https://github.com/redhat-developer/rhdh-local/blob/main/compose.yaml) file
+2. Start RHDH with the optional Postgres overlay [`compose-with-db.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/compose-with-db.yaml). Do not edit the default [`compose.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/compose.yaml).
 
-   ```yaml
-   db:
-     image: "registry.redhat.io/rhel10/postgresql-18:latest"
-     volumes:
-       - "/var/lib/pgsql/data"
-     env_file:
-       - path: "./default.env"
-         required: true
-       - path: "./.env"
-         required: false
-     environment:
-       - POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD}
-     healthcheck:
-       test: ["CMD", "pg_isready", "-U", "postgres"]
-       interval: 5s
-       timeout: 5s
-       retries: 5
-   ```
+   Note that the order of the YAML files is important:
 
-3. Uncomment the `db` section in the `depends_on` section of `rhdh` service in [https://github.com/redhat-developer/rhdh-local/blob/main/compose.yaml](https://github.com/redhat-developer/rhdh-local/blob/main/compose.yaml)
+   === "Podman"
+       ```bash
+       podman compose -f compose.yaml -f compose-with-db.yaml up -d
+       ```
 
-   ```yaml
-   depends_on:
-     install-dynamic-plugins:
-       condition: service_completed_successfully
-     db:
-       condition: service_healthy
-   ```
+   === "Docker"
+       ```bash
+       docker compose -f compose.yaml -f compose-with-db.yaml up -d
+       ```
 
-4. Comment out the SQLite in-memory configuration in [`app-config.local.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/configs/app-config/app-config.local.example.yaml)
+   You can combine this with other overlays the same way. For example, with the [corporate proxy](corporate-proxy-setup-sim.md) setup:
+
+   === "Podman"
+       ```bash
+       podman compose -f compose.yaml -f compose-with-db.yaml -f compose-with-corporate-proxy.yaml up -d
+       ```
+
+   === "Docker"
+       ```bash
+       docker compose -f compose.yaml -f compose-with-db.yaml -f compose-with-corporate-proxy.yaml up -d
+       ```
+
+3. Comment out the SQLite in-memory configuration in [`app-config.local.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/configs/app-config/app-config.local.example.yaml)
 
    ```yaml
    # database:
@@ -56,7 +51,7 @@ The examples below use `podman` and `podman compose`. If you use Docker, replace
    #   connection: ':memory:'
    ```
 
-5. Add Postgres configuration in [`app-config.local.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/configs/app-config/app-config.local.example.yaml)
+4. Add Postgres configuration in [`app-config.local.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/configs/app-config/app-config.local.example.yaml)
 
    ```yaml
    database:
@@ -92,6 +87,8 @@ The new image must support upgrading from your current major version (its `POSTG
 
 The `psql` examples below use `POSTGRES_USER` from the container environment (`default.env` / `.env`). `sh -c` is required so the variable expands inside the container.
 
+In the commands below, keep every `-f` overlay you already use day to day (at least `-f compose.yaml -f compose-with-db.yaml`). If you also run with the corporate proxy, include `-f compose-with-corporate-proxy.yaml` on the same commands.
+
 ### Steps
 
 1. Note your current Postgres version and image:
@@ -104,10 +101,10 @@ The `psql` examples below use `POSTGRES_USER` from the container environment (`d
 2. Stop RHDH so it does not write during the upgrade:
 
    ```sh
-   podman compose stop rhdh
+   podman compose -f compose.yaml -f compose-with-db.yaml stop rhdh
    ```
 
-3. In `compose.yaml`, set `db.image` to the newer Postgres image and add `POSTGRESQL_UPGRADE=copy` for this boot only:
+3. In [`compose-with-db.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/compose-with-db.yaml), set `db.image` to the newer Postgres image and add `POSTGRESQL_UPGRADE=copy` for this boot only:
 
    ```yaml
    db:
@@ -121,10 +118,10 @@ The `psql` examples below use `POSTGRES_USER` from the container environment (`d
 4. Recreate and start the `db` **container** so it boots the new image against the **existing** data volume (do **not** run `podman compose down --volumes` / `docker compose down --volumes`):
 
    ```sh
-   podman compose up -d db
+   podman compose -f compose.yaml -f compose-with-db.yaml up -d db
    ```
 
-   Wait until `db` is healthy (`podman compose ps`), then confirm the new major version:
+   Wait until `db` is healthy (`podman compose -f compose.yaml -f compose-with-db.yaml ps`), then confirm the new major version:
 
    ```sh
    podman exec db sh -c 'psql -U "${POSTGRES_USER:-postgres}" -c "SHOW server_version;"'
@@ -141,10 +138,10 @@ The `psql` examples below use `POSTGRES_USER` from the container environment (`d
    # podman exec db sh -c 'psql -U "${POSTGRES_USER:-postgres}" -c "ALTER DATABASE \"<dbname>\" REFRESH COLLATION VERSION;"'
    ```
 
-6. Remove `POSTGRESQL_UPGRADE=copy` from `compose.yaml`, then force-recreate only the `db` **container** so the updated environment takes effect:
+6. Remove `POSTGRESQL_UPGRADE=copy` from `compose-with-db.yaml`, then force-recreate only the `db` **container** so the updated environment takes effect:
 
    ```sh
-   podman compose up -d --force-recreate db
+   podman compose -f compose.yaml -f compose-with-db.yaml up -d --force-recreate db
    ```
 
    `--force-recreate` replaces the container; it does **not** create a fresh database or wipe `/var/lib/pgsql/data`. Compose keeps the existing volume as long as you do not pass `--volumes` / `-v` to `podman compose down` / `docker compose down` or otherwise remove that volume.
@@ -152,7 +149,7 @@ The `psql` examples below use `POSTGRES_USER` from the container environment (`d
 7. Start RHDH again and verify the instance:
 
    ```sh
-   podman compose up -d rhdh
+   podman compose -f compose.yaml -f compose-with-db.yaml up -d rhdh
    ```
 
    Open [http://localhost:7007](http://localhost:7007) and confirm your catalog (or other persisted data) is still present.

--- a/docs/rhdh-local-guide/postgresql-guide.md
+++ b/docs/rhdh-local-guide/postgresql-guide.md
@@ -95,7 +95,7 @@ The `psql` examples below use `POSTGRES_USER` from the container environment (`d
 3. Point at the target major image and enable a one-time upgrade boot:
 
    - In your project `.env`, set `POSTGRES_IMAGE` to the newer image (for example `registry.redhat.io/rhel10/postgresql-18:latest`).
-   - Copy the temporary override example (do not commit `compose.override.yaml`):
+   - Copy the temporary override example:
 
    ```sh
    cp compose.postgres-upgrade.override.example.yaml compose.override.yaml

--- a/docs/rhdh-local-guide/postgresql-guide.md
+++ b/docs/rhdh-local-guide/postgresql-guide.md
@@ -7,9 +7,9 @@ If you want to use PostgreSQL with RHDH, here are the steps:
 
 The examples below use `podman` and `podman compose`. If you use Docker, replace `podman` with `docker` (for example `docker login`, `docker compose`, `docker exec`).
 
-`default.env` already supplies the `POSTGRES_*` defaults via `env_file`. Put only the values you want to change in your project `.env` (or export them). You do not need to copy every `POSTGRES_*` key.
+`default.env` already supplies the `POSTGRES_*` defaults via `env_file`. Put only the values you want to change in your project `.env` (or export them). You do not need to copy every `POSTGRES_*` key. You can pin the Postgres image with `POSTGRES_IMAGE` in `.env` (see `compose-with-db.yaml`).
 
-> **Warning:** If you already run optional Postgres and have a persisted `/var/lib/pgsql/data` volume from an **older major** image, do **not** only change `db.image` to a newer major. Follow [Upgrading PostgreSQL](#upgrading-postgresql) first so the volume is upgraded safely.
+> **Warning:** If you already run optional Postgres and have a persisted `/var/lib/pgsql/data` volume from an **older major** image, do **not** only bump `POSTGRES_IMAGE` (or the default image major). Follow [Upgrading PostgreSQL](#upgrading-postgresql) first so the volume is upgraded safely.
 
 1. Login to container registry with *Red Hat Login* credentials to use `postgresql` image
 
@@ -17,31 +17,17 @@ The examples below use `podman` and `podman compose`. If you use Docker, replace
    podman login registry.redhat.io
    ```
 
-2. Start RHDH with the optional Postgres overlay [`compose-with-db.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/compose-with-db.yaml). Do not edit the default [`compose.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/compose.yaml).
+2. Start RHDH with the optional Postgres overlay [`compose-with-db.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/compose-with-db.yaml). Note that the order of the YAML files is important:
 
-   Note that the order of the YAML files is important:
-
-   === "Podman"
-       ```bash
-       podman compose -f compose.yaml -f compose-with-db.yaml up -d
-       ```
-
-   === "Docker"
-       ```bash
-       docker compose -f compose.yaml -f compose-with-db.yaml up -d
-       ```
+   ```sh
+   podman compose -f compose.yaml -f compose-with-db.yaml up -d
+   ```
 
    You can combine this with other overlays the same way. For example, with the [corporate proxy](corporate-proxy-setup-sim.md) setup:
 
-   === "Podman"
-       ```bash
-       podman compose -f compose.yaml -f compose-with-db.yaml -f compose-with-corporate-proxy.yaml up -d
-       ```
-
-   === "Docker"
-       ```bash
-       docker compose -f compose.yaml -f compose-with-db.yaml -f compose-with-corporate-proxy.yaml up -d
-       ```
+   ```sh
+   podman compose -f compose.yaml -f compose-with-db.yaml -f compose-with-corporate-proxy.yaml up -d
+   ```
 
 3. Comment out the SQLite in-memory configuration in [`app-config.local.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/configs/app-config/app-config.local.example.yaml)
 
@@ -85,9 +71,11 @@ The new image must support upgrading from your current major version (its `POSTG
 
 > **Warning:** Back up the Postgres data volume (or take a host-level snapshot) before upgrading. Stop RHDH first so nothing writes to the database during the upgrade. The `copy` mode needs roughly as much free space as the current data directory.
 
-The `psql` examples below use `POSTGRES_USER` from the container environment (`default.env` / `.env`). `sh -c` is required so the variable expands inside the container.
+Do not edit tracked [`compose-with-db.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/compose-with-db.yaml) for the upgrade. Put temporary settings in gitignored `compose.override.yaml` instead. Pulling a newer default image major in `compose-with-db.yaml` is not a silent safe upgrade for an existing data volume — follow the steps below when the image major changes.
 
-In the commands below, keep every `-f` overlay you already use day to day (at least `-f compose.yaml -f compose-with-db.yaml`). If you also run with the corporate proxy, include `-f compose-with-corporate-proxy.yaml` on the same commands.
+When using `-f compose-with-db.yaml`, Compose does not auto-load `compose.override.yaml`. Include it explicitly on upgrade commands. Keep every other `-f` overlay you already use (for example `-f compose-with-corporate-proxy.yaml`).
+
+The `psql` examples below use `POSTGRES_USER` from the container environment (`default.env` / `.env`). `sh -c` is required so the variable expands inside the container.
 
 ### Steps
 
@@ -104,24 +92,24 @@ In the commands below, keep every `-f` overlay you already use day to day (at le
    podman compose -f compose.yaml -f compose-with-db.yaml stop rhdh
    ```
 
-3. In [`compose-with-db.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/compose-with-db.yaml), set `db.image` to the newer Postgres image and add `POSTGRESQL_UPGRADE=copy` for this boot only:
+3. Point at the target major image and enable a one-time upgrade boot:
 
-   ```yaml
-   db:
-     image: "registry.redhat.io/<newer-postgresql-image>:latest"
-     # ...existing volumes, env_file, healthcheck...
-     environment:
-       - POSTGRESQL_ADMIN_PASSWORD=${POSTGRES_PASSWORD}
-       - POSTGRESQL_UPGRADE=copy
+   - In your project `.env`, set `POSTGRES_IMAGE` to the newer image (for example `registry.redhat.io/rhel10/postgresql-18:latest`).
+   - Copy the temporary override example (do not commit `compose.override.yaml`):
+
+   ```sh
+   cp compose.postgres-upgrade.override.example.yaml compose.override.yaml
    ```
+
+   That override only adds `POSTGRESQL_UPGRADE=copy` for this boot.
 
 4. Recreate and start the `db` **container** so it boots the new image against the **existing** data volume (do **not** run `podman compose down --volumes` / `docker compose down --volumes`):
 
    ```sh
-   podman compose -f compose.yaml -f compose-with-db.yaml up -d db
+   podman compose -f compose.yaml -f compose-with-db.yaml -f compose.override.yaml up -d db
    ```
 
-   Wait until `db` is healthy (`podman compose -f compose.yaml -f compose-with-db.yaml ps`), then confirm the new major version:
+   Wait until `db` is healthy (`podman compose -f compose.yaml -f compose-with-db.yaml -f compose.override.yaml ps`), then confirm the new major version:
 
    ```sh
    podman exec db sh -c 'psql -U "${POSTGRES_USER:-postgres}" -c "SHOW server_version;"'
@@ -138,11 +126,14 @@ In the commands below, keep every `-f` overlay you already use day to day (at le
    # podman exec db sh -c 'psql -U "${POSTGRES_USER:-postgres}" -c "ALTER DATABASE \"<dbname>\" REFRESH COLLATION VERSION;"'
    ```
 
-6. Remove `POSTGRESQL_UPGRADE=copy` from `compose-with-db.yaml`, then force-recreate only the `db` **container** so the updated environment takes effect:
+6. Remove `POSTGRESQL_UPGRADE` by deleting `compose.override.yaml` (or stripping that env from it), then force-recreate only the `db` **container** so the updated environment takes effect:
 
    ```sh
+   rm compose.override.yaml
    podman compose -f compose.yaml -f compose-with-db.yaml up -d --force-recreate db
    ```
+
+   Keep `POSTGRES_IMAGE` in `.env` if you want to pin the major; otherwise the default from `compose-with-db.yaml` applies.
 
    `--force-recreate` replaces the container; it does **not** create a fresh database or wipe `/var/lib/pgsql/data`. Compose keeps the existing volume as long as you do not pass `--volumes` / `-v` to `podman compose down` / `docker compose down` or otherwise remove that volume.
 
@@ -156,6 +147,7 @@ In the commands below, keep every `-f` overlay you already use day to day (at le
 
 ### What not to do
 
+- Do not edit `compose-with-db.yaml` for upgrades (use `.env` + temporary `compose.override.yaml`).
 - Do not delete the Postgres data volume as part of this upgrade (`podman compose down --volumes` / `docker compose down --volumes`, `volume rm`, pruning volumes, etc.).
 - Do not treat `--force-recreate db` as a data reset — it only recreates the container.
 - Do not leave `POSTGRESQL_UPGRADE` set after the upgrade succeeds.

--- a/docs/rhdh-local-guide/postgresql-guide.md
+++ b/docs/rhdh-local-guide/postgresql-guide.md
@@ -7,7 +7,7 @@ If you want to use PostgreSQL with RHDH, here are the steps:
 
 The examples below use `podman` and `podman compose`. If you use Docker, replace `podman` with `docker` (for example `docker login`, `docker compose`, `docker exec`).
 
-`default.env` already supplies the `POSTGRES_*` defaults via `env_file`. Put only the values you want to change in your project `.env` (or export them). You do not need to copy every `POSTGRES_*` key. You can pin the Postgres image with `POSTGRES_IMAGE` in `.env` (see `compose-with-db.yaml`).
+`default.env` already supplies the `POSTGRES_*` defaults via `env_file`. Put only the values you want to change in your project `.env` (or export them). You do not need to copy every `POSTGRES_*` key. You can pin the Postgres image with `POSTGRES_IMAGE` in `.env` (see [`compose-with-db.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/compose-with-db.yaml)).
 
 > **Warning:** If you already run optional Postgres and have a persisted `/var/lib/pgsql/data` volume from an **older major** image, do **not** only bump `POSTGRES_IMAGE` (or the default image major). Follow [Upgrading PostgreSQL](#upgrading-postgresql) first so the volume is upgraded safely.
 

--- a/docs/rhdh-local-guide/postgresql-guide.md
+++ b/docs/rhdh-local-guide/postgresql-guide.md
@@ -29,39 +29,25 @@ The examples below use `podman` and `podman compose`. If you use Docker, replace
    podman compose -f compose.yaml -f compose-with-db.yaml -f compose-with-corporate-proxy.yaml up -d
    ```
 
-3. Comment out the SQLite in-memory configuration in [`app-config.local.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/configs/app-config/app-config.local.example.yaml)
+   The overlay sets `WITH_POSTGRES=true` on the `rhdh` service. On startup, RHDH automatically generates a Postgres `backend.database` config and loads it after the default SQLite settings. You do not need to edit [`app-config.local.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/configs/app-config/app-config.local.example.yaml) for basic Postgres use.
 
-   ```yaml
-   # database:
-   #   client: better-sqlite3
-   #   connection: ':memory:'
-   ```
+### Optional database overrides
 
-4. Add Postgres configuration in [`app-config.local.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/configs/app-config/app-config.local.example.yaml)
+Put database overrides in [`app-config.local.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/configs/app-config/app-config.local.example.yaml). That file is loaded last, so it wins over the generated Postgres config. For example, an explicit SQLite block would switch you back to in-memory storage even with the overlay.
 
-   ```yaml
-   database:
+If you need `pluginDivisionMode: schema` (one database, one schema per plugin — useful when the DB user cannot create multiple databases), add this to `app-config.local.yaml`:
+
+```yaml
+backend:
+  database:
     client: pg
+    pluginDivisionMode: schema
     connection:
       host: ${POSTGRES_HOST}
       port: ${POSTGRES_PORT}
       user: ${POSTGRES_USER}
       password: ${POSTGRES_PASSWORD}
-   ```
-
-   If you need `pluginDivisionMode: schema` (one database, one schema per plugin — useful when the DB user cannot create multiple databases), use this `backend.database` block in `app-config.local.yaml` instead of the snippet above:
-
-   ```yaml
-   backend:
-     database:
-       client: pg
-       pluginDivisionMode: schema
-       connection:
-         host: ${POSTGRES_HOST}
-         port: ${POSTGRES_PORT}
-         user: ${POSTGRES_USER}
-         password: ${POSTGRES_PASSWORD}
-   ```
+```
 
 ## Upgrading PostgreSQL
 

--- a/docs/rhdh-local-guide/postgresql-guide.md
+++ b/docs/rhdh-local-guide/postgresql-guide.md
@@ -29,13 +29,13 @@ The examples below use `podman` and `podman compose`. If you use Docker, replace
    podman compose -f compose.yaml -f compose-with-db.yaml -f compose-with-corporate-proxy.yaml up -d
    ```
 
-   The overlay sets `WITH_POSTGRES=true` on the `rhdh` service. On startup, RHDH loads the Postgres `backend.database` config from [`configs/app-config/app-config.db.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/configs/app-config/app-config.db.yaml) after the default SQLite settings. You do not need to edit [`app-config.local.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/configs/app-config/app-config.local.example.yaml) for basic Postgres use.
+   The overlay sets `WITH_POSTGRES=true` on the `rhdh` service. On startup, RHDH loads the Postgres `backend.database` config from [`app-config.db.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/configs/app-config/app-config.db.yaml) after the default SQLite settings. You do not need to edit [`app-config.local.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/configs/app-config/app-config.local.example.yaml) for basic Postgres use.
 
 ### Optional database overrides
 
-Put database overrides in [`app-config.local.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/configs/app-config/app-config.local.example.yaml). That file is loaded last, so it wins over `app-config.db.yaml`. For example, an explicit SQLite block would switch you back to in-memory storage even with the overlay.
+Put database overrides in [`app-config.local.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/configs/app-config/app-config.local.example.yaml). That file is loaded last, so it wins over [`app-config.db.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/configs/app-config/app-config.db.yaml). For example, an explicit SQLite block would switch you back to in-memory storage even with the overlay.
 
-If you need `pluginDivisionMode: schema` (one database, one schema per plugin — useful when the DB user cannot create multiple databases), add this to `app-config.local.yaml`. Deep merge keeps `client` and `connection` from `app-config.db.yaml`:
+If you need `pluginDivisionMode: schema` (one database, one schema per plugin — useful when the DB user cannot create multiple databases), add this to `app-config.local.yaml`. Deep merge keeps `client` and `connection` from [`app-config.db.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/configs/app-config/app-config.db.yaml):
 
 ```yaml
 backend:

--- a/docs/rhdh-local-guide/postgresql-guide.md
+++ b/docs/rhdh-local-guide/postgresql-guide.md
@@ -29,24 +29,18 @@ The examples below use `podman` and `podman compose`. If you use Docker, replace
    podman compose -f compose.yaml -f compose-with-db.yaml -f compose-with-corporate-proxy.yaml up -d
    ```
 
-   The overlay sets `WITH_POSTGRES=true` on the `rhdh` service. On startup, RHDH automatically generates a Postgres `backend.database` config and loads it after the default SQLite settings. You do not need to edit [`app-config.local.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/configs/app-config/app-config.local.example.yaml) for basic Postgres use.
+   The overlay sets `WITH_POSTGRES=true` on the `rhdh` service. On startup, RHDH loads the Postgres `backend.database` config from [`configs/app-config/app-config.db.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/configs/app-config/app-config.db.yaml) after the default SQLite settings. You do not need to edit [`app-config.local.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/configs/app-config/app-config.local.example.yaml) for basic Postgres use.
 
 ### Optional database overrides
 
-Put database overrides in [`app-config.local.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/configs/app-config/app-config.local.example.yaml). That file is loaded last, so it wins over the generated Postgres config. For example, an explicit SQLite block would switch you back to in-memory storage even with the overlay.
+Put database overrides in [`app-config.local.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/configs/app-config/app-config.local.example.yaml). That file is loaded last, so it wins over `app-config.db.yaml`. For example, an explicit SQLite block would switch you back to in-memory storage even with the overlay.
 
-If you need `pluginDivisionMode: schema` (one database, one schema per plugin — useful when the DB user cannot create multiple databases), add this to `app-config.local.yaml`:
+If you need `pluginDivisionMode: schema` (one database, one schema per plugin — useful when the DB user cannot create multiple databases), add this to `app-config.local.yaml`. Deep merge keeps `client` and `connection` from `app-config.db.yaml`:
 
 ```yaml
 backend:
   database:
-    client: pg
     pluginDivisionMode: schema
-    connection:
-      host: ${POSTGRES_HOST}
-      port: ${POSTGRES_PORT}
-      user: ${POSTGRES_USER}
-      password: ${POSTGRES_PASSWORD}
 ```
 
 ## Upgrading PostgreSQL

--- a/wait-for-plugins-and-start.sh
+++ b/wait-for-plugins-and-start.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 DYNAMIC_PLUGINS_CONFIG="dynamic-plugins-root/app-config.dynamic-plugins.yaml"
 DEFAULT_APP_CONFIG="configs/app-config/app-config.yaml"
 PATCHED_APP_CONFIG="generated/app-config.patched.yaml"
-DB_APP_CONFIG="generated/app-config-db.yaml"
+DB_APP_CONFIG="configs/app-config/app-config.db.yaml"
 
 USER_APP_CONFIG="configs/app-config/app-config.local.yaml"
 LEGACY_USER_APP_CONFIG="configs/app-config.local.yaml"
@@ -51,17 +51,7 @@ fi
 # Loaded after the patched default config (SQLite) and before user local config.
 EXTRA_CONFIGS=""
 if [[ "${WITH_POSTGRES:-}" == "true" ]]; then
-  cat > "$DB_APP_CONFIG" <<'EOF'
-backend:
-  database:
-    client: pg
-    connection:
-      host: ${POSTGRES_HOST}
-      port: ${POSTGRES_PORT}
-      user: ${POSTGRES_USER}
-      password: ${POSTGRES_PASSWORD}
-EOF
-  echo "Using generated Postgres config: $DB_APP_CONFIG"
+  echo "Using Postgres config: $DB_APP_CONFIG"
   EXTRA_CONFIGS="$DB_APP_CONFIG"
 fi
 

--- a/wait-for-plugins-and-start.sh
+++ b/wait-for-plugins-and-start.sh
@@ -36,13 +36,13 @@ fi
 cp -f "$DEFAULT_APP_CONFIG" "$PATCHED_APP_CONFIG"
 
 # Wait until the dynamic plugin config is ready
-while [ ! -f "$DYNAMIC_PLUGINS_CONFIG" ]; do
+while [[ ! -f "$DYNAMIC_PLUGINS_CONFIG" ]]; do
   echo "Waiting for $DYNAMIC_PLUGINS_CONFIG to be created by install-dynamic-plugins container ..."
   sleep 2
 done
 
 # Apply overrides by replacing target paths in the patched config
-if [ -f "$USERS_OVERRIDE" ]; then
+if [[ -f "$USERS_OVERRIDE" ]]; then
   echo "Applying users override"
   sed -i "s|/opt/app-root/src/configs/catalog-entities/users.yaml|/opt/app-root/src/$USERS_OVERRIDE|" "$PATCHED_APP_CONFIG"
 fi
@@ -50,7 +50,7 @@ fi
 # Auto-wire Postgres when compose-with-db sets WITH_POSTGRES=true.
 # Loaded after the patched default config (SQLite) and before user local config.
 EXTRA_CONFIGS=""
-if [ "${WITH_POSTGRES:-}" = "true" ]; then
+if [[ "${WITH_POSTGRES:-}" == "true" ]]; then
   cat > "$DB_APP_CONFIG" <<'EOF'
 backend:
   database:
@@ -66,10 +66,10 @@ EOF
 fi
 
 # Add local config if available (always last so users can override)
-if [ -f "$USER_APP_CONFIG" ]; then
+if [[ -f "$USER_APP_CONFIG" ]]; then
   echo "Using user config: $USER_APP_CONFIG"
   EXTRA_CONFIGS="$EXTRA_CONFIGS $USER_APP_CONFIG"
-elif [ -f "$LEGACY_USER_APP_CONFIG" ]; then
+elif [[ -f "$LEGACY_USER_APP_CONFIG" ]]; then
   echo "[warn] Using legacy app-config.local.yaml. This is deprecated. Please migrate to $USER_APP_CONFIG."
   EXTRA_CONFIGS="$EXTRA_CONFIGS $LEGACY_USER_APP_CONFIG"
 fi

--- a/wait-for-plugins-and-start.sh
+++ b/wait-for-plugins-and-start.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 DYNAMIC_PLUGINS_CONFIG="dynamic-plugins-root/app-config.dynamic-plugins.yaml"
 DEFAULT_APP_CONFIG="configs/app-config/app-config.yaml"
 PATCHED_APP_CONFIG="generated/app-config.patched.yaml"
+DB_APP_CONFIG="generated/app-config-db.yaml"
 
 USER_APP_CONFIG="configs/app-config/app-config.local.yaml"
 LEGACY_USER_APP_CONFIG="configs/app-config.local.yaml"
@@ -46,14 +47,31 @@ if [ -f "$USERS_OVERRIDE" ]; then
   sed -i "s|/opt/app-root/src/configs/catalog-entities/users.yaml|/opt/app-root/src/$USERS_OVERRIDE|" "$PATCHED_APP_CONFIG"
 fi
 
-# Add local config if available
+# Auto-wire Postgres when compose-with-db sets WITH_POSTGRES=true.
+# Loaded after the patched default config (SQLite) and before user local config.
 EXTRA_CONFIGS=""
+if [ "${WITH_POSTGRES:-}" = "true" ]; then
+  cat > "$DB_APP_CONFIG" <<'EOF'
+backend:
+  database:
+    client: pg
+    connection:
+      host: ${POSTGRES_HOST}
+      port: ${POSTGRES_PORT}
+      user: ${POSTGRES_USER}
+      password: ${POSTGRES_PASSWORD}
+EOF
+  echo "Using generated Postgres config: $DB_APP_CONFIG"
+  EXTRA_CONFIGS="$DB_APP_CONFIG"
+fi
+
+# Add local config if available (always last so users can override)
 if [ -f "$USER_APP_CONFIG" ]; then
   echo "Using user config: $USER_APP_CONFIG"
-  EXTRA_CONFIGS="$USER_APP_CONFIG"
+  EXTRA_CONFIGS="$EXTRA_CONFIGS $USER_APP_CONFIG"
 elif [ -f "$LEGACY_USER_APP_CONFIG" ]; then
   echo "[warn] Using legacy app-config.local.yaml. This is deprecated. Please migrate to $USER_APP_CONFIG."
-  EXTRA_CONFIGS="$LEGACY_USER_APP_CONFIG"
+  EXTRA_CONFIGS="$EXTRA_CONFIGS $LEGACY_USER_APP_CONFIG"
 fi
 
 EXTRA_CLI_ARGS=""


### PR DESCRIPTION
## Description

Fixes [RHDHBUGS-1865](https://redhat.atlassian.net/browse/RHDHBUGS-1865): enabling the optional PostgreSQL service no longer requires uncommenting blocks in the default `compose.yaml` (which caused merge conflicts on pull).

- Add [`compose-with-db.yaml`](compose-with-db.yaml) overlay (same pattern as `compose-with-corporate-proxy.yaml` / `compose-dynamic-plugins-root.yaml`)
- Point `compose.yaml` at the overlay instead of a commented `db` service
- Update the PostgreSQL guide for `-f compose.yaml -f compose-with-db.yaml`, including a combined example with `compose-with-corporate-proxy.yaml`
- Major upgrades use temporary gitignored `compose.override.yaml` + `POSTGRES_IMAGE` (do not edit tracked `compose-with-db.yaml`)

**Stacked on** #278 (`docs/pg16-to-pg18-upgrade`) — GitHub stack #286 targeting `dev`.

## Which issue(s) does this PR fix or relate to

- Fixes RHDHBUGS-1865
- Depends on #278

## PR acceptance criteria

- [ ] Tests updated and passing
- [x] Documentation updated
- [x] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

## How to test changes / Special notes to the reviewer

1. Do **not** edit `compose.yaml` for Postgres
2. `podman login registry.redhat.io`
3. Copy `POSTGRES_*` into `.env`; switch `app-config.local.yaml` from SQLite to `pg` as in the guide
4. `podman compose -f compose.yaml -f compose-with-db.yaml up -d` → `db` healthy, RHDH up
5. Optional: `podman compose -f compose.yaml -f compose-with-db.yaml -f compose-with-corporate-proxy.yaml config` merges `db` + `proxy` + `rhdh.depends_on`
6. `npx --yes dclint compose-with-db.yaml` → 0 errors