### PR TITLE
docs: document `main`/`dev` branching strategy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,19 @@
 Thank you for opening a PR! Please take the time to fill in the details below.
 -->
 
+## Target branch
+
+<!--
+This repository uses a main/dev branching model. Please confirm that
+your PR targets the correct branch:
+
+- `dev`: next-release features and RHDH-version-specific changes
+- `main`: version-independent changes (documentation fixes, CI updates, etc.)
+- `release-x.y`: fixes for a specific supported release branch
+-->
+
+- [ ] I have verified this PR targets the correct branch
+
 ## Description
 <!--
 Please explain the changes you made here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,9 +8,10 @@ Thank you for opening a PR! Please take the time to fill in the details below.
 This repository uses a main/dev branching model. Please confirm that
 your PR targets the correct branch:
 
-- `dev`: next-release features and RHDH-version-specific changes
-- `main`: version-independent changes (documentation fixes, CI updates, etc.)
-- `release-x.y`: fixes for a specific supported release branch
+- `dev`: all development work (features, docs, dependency updates, etc.)
+- `release-x.y`: bug fixes for a specific supported release
+
+Do not target `main` directly; maintainers manage it via merges and cherry-picks.
 -->
 
 - [ ] I have verified this PR targets the correct branch (see [branching strategy](https://github.com/redhat-developer/rhdh-local/blob/HEAD/docs/rhdh-local-guide/help-and-contrib.md#branching-model))

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@ your PR targets the correct branch:
 - `release-x.y`: fixes for a specific supported release branch
 -->
 
-- [ ] I have verified this PR targets the correct branch (see [branching strategy](../docs/rhdh-local-guide/help-and-contrib.md#branching-model))
+- [ ] I have verified this PR targets the correct branch (see [branching strategy](https://github.com/redhat-developer/rhdh-local/blob/HEAD/docs/rhdh-local-guide/help-and-contrib.md#branching-model))
 
 ## Description
 <!--

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@ your PR targets the correct branch:
 - `release-x.y`: fixes for a specific supported release branch
 -->
 
-- [ ] I have verified this PR targets the correct branch
+- [ ] I have verified this PR targets the correct branch (see [branching strategy](../docs/rhdh-local-guide/help-and-contrib.md#branching-model))
 
 ## Description
 <!--

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches:
       - main
+      - dev
       - release-[0-9]+.[0-9]+
   pull_request:
     branches:
       - main
+      - dev
       - release-[0-9]+.[0-9]+
 
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,12 +4,10 @@ on:
   push:
     branches:
       - main
-      - dev
       - release-[0-9]+.[0-9]+
   pull_request:
     branches:
       - main
-      - dev
       - release-[0-9]+.[0-9]+
 
 concurrency:

--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ To browse the existing issues, you can use this [Query](https://issues.redhat.co
 
 Contributions are welcome! This repository uses a `main`/`dev` branching model:
 
-- **`main`** (default branch) tracks the latest stable GA release of RHDH. Target `main` for version-independent changes (documentation fixes, GitHub Actions dependency updates, etc.).
-- **`dev`** tracks the upcoming RHDH release (`next` tag). Target `dev` for next-release features and RHDH-version-specific changes.
+- **`main`** (default branch) tracks the latest stable GA release of RHDH. Maintainers manage this branch; do not target PRs to `main` directly.
+- **`dev`** tracks the upcoming RHDH release (`next` tag). All development PRs should target `dev`.
+- **`release-x.y`** branches are used for release stabilization and bug fixes for a specific supported release.
 
 See the [built-in Contributing guide](./docs/rhdh-local-guide/help-and-contrib.md) for details.
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,12 @@ To report issues against this repository, please use [JIRA](https://issues.redha
 
 To browse the existing issues, you can use this [Query](https://issues.redhat.com/issues/?filter=-4&jql=project%20%3D%20%22Red%20Hat%20Internal%20Developer%20Platform%22%20%20AND%20component%20%3D%20%22RHDH%20Local%22%20AND%20resolution%20%3D%20Unresolved%20ORDER%20BY%20status%2C%20priority%2C%20updated%20%20%20%20DESC).
 
-Contributions are welcome!
+Contributions are welcome! This repository uses a `main`/`dev` branching model:
+
+- **`main`** (default branch) tracks the latest stable GA release of RHDH. Target `main` for version-independent changes (documentation fixes, GitHub Actions dependency updates, etc.).
+- **`dev`** tracks the upcoming RHDH release (`next` tag). Target `dev` for next-release features and RHDH-version-specific changes.
+
+See the [built-in Contributing guide](./docs/rhdh-local-guide/help-and-contrib.md) for details.
 
 
 ## Breaking changes and known issues

--- a/docs/rhdh-local-guide/help-and-contrib.md
+++ b/docs/rhdh-local-guide/help-and-contrib.md
@@ -127,6 +127,7 @@ git clone https://github.com/YOUR-USERNAME/rhdh-local.git && cd rhdh-local
 
 # Add upstream remote for staying current
 git remote add upstream https://github.com/redhat-developer/rhdh-local.git
+git fetch upstream
 
 # Create a branch from dev (see "Which branch should my PR target?" above)
 git checkout -b feature/my-contribution upstream/dev

--- a/docs/rhdh-local-guide/help-and-contrib.md
+++ b/docs/rhdh-local-guide/help-and-contrib.md
@@ -95,6 +95,29 @@ We actively encourage contributions of all types! Here's how you can help:
 - **Create example setups** for specific scenarios
 - **Document best practices** from real-world usage
 
+### Branching Model
+
+This repository uses a `main`/`dev` branching model to separate stable content from active development:
+
+| Branch | Purpose | Tracks |
+|---|---|---|
+| **`main`** (default) | Latest stable GA release of RHDH | Current GA RHDH version |
+| **`dev`** | Active development for the upcoming RHDH release | RHDH `next` tag |
+| **`release-x.y`** | Release stabilization and patch releases | Specific RHDH version |
+
+#### Which branch should my PR target?
+
+| Change type | Target branch |
+|---|---|
+| Next-release features or RHDH-version-specific changes | `dev` |
+| Version-independent changes (documentation fixes, CI updates, etc.) | `main` |
+| Fixes for a specific supported release | `release-x.y` |
+
+At Feature Freeze, a `release-x.y` branch is created from `dev` for stabilization. At GA, the release branch is merged into `main`, so `main` always reflects the latest stable RHDH release.
+
+!!! tip "When in doubt"
+    If your change is tied to a specific RHDH version, target `dev`. If it applies regardless of the RHDH version, target `main`.
+
 ### Contribution Workflow
 
 #### 1. Prepare Your Environment
@@ -107,8 +130,11 @@ git clone https://github.com/YOUR-USERNAME/rhdh-local.git && cd rhdh-local
 # Add upstream remote for staying current
 git remote add upstream https://github.com/redhat-developer/rhdh-local.git
 
-# Create a development branch
-git checkout -b feature/my-contribution
+# Create a branch from the correct base (see "Which branch should my PR target?" above)
+# For next-release work:
+git checkout -b feature/my-contribution upstream/dev
+# For version-independent changes:
+git checkout -b fix/my-fix upstream/main
 ```
 
 #### 2. Development Guidelines

--- a/docs/rhdh-local-guide/help-and-contrib.md
+++ b/docs/rhdh-local-guide/help-and-contrib.md
@@ -128,6 +128,7 @@ git clone https://github.com/YOUR-USERNAME/rhdh-local.git && cd rhdh-local
 # Add upstream remote for staying current
 git remote add upstream https://github.com/redhat-developer/rhdh-local.git
 git fetch upstream
+git fetch upstream
 
 # Create a branch from dev (see "Which branch should my PR target?" above)
 git checkout -b feature/my-contribution upstream/dev

--- a/docs/rhdh-local-guide/help-and-contrib.md
+++ b/docs/rhdh-local-guide/help-and-contrib.md
@@ -128,7 +128,6 @@ git clone https://github.com/YOUR-USERNAME/rhdh-local.git && cd rhdh-local
 # Add upstream remote for staying current
 git remote add upstream https://github.com/redhat-developer/rhdh-local.git
 git fetch upstream
-git fetch upstream
 
 # Create a branch from dev (see "Which branch should my PR target?" above)
 git checkout -b feature/my-contribution upstream/dev

--- a/docs/rhdh-local-guide/help-and-contrib.md
+++ b/docs/rhdh-local-guide/help-and-contrib.md
@@ -109,14 +109,12 @@ This repository uses a `main`/`dev` branching model to separate stable content f
 
 | Change type | Target branch |
 |---|---|
-| Next-release features or RHDH-version-specific changes | `dev` |
-| Version-independent changes (documentation fixes, CI updates, etc.) | `main` |
-| Fixes for a specific supported release | `release-x.y` |
+| All development work (features, docs, dependency updates, etc.) | `dev` |
+| Bug fixes for a specific supported release | `release-x.y` |
 
-At Feature Freeze, a `release-x.y` branch is created from `dev` for stabilization. At GA, the release branch is merged into `main`, so `main` always reflects the latest stable RHDH release.
+Do not target `main` directly. Maintainers manage `main` via merges and cherry-picks.
 
-!!! tip "When in doubt"
-    If your change is tied to a specific RHDH version, target `dev`. If it applies regardless of the RHDH version, target `main`.
+At Feature Freeze, a `release-x.y` branch is created from `dev` for stabilization. At GA, the release branch is merged into `main`, so `main` always reflects the latest stable RHDH release. Maintainers cherry-pick changes to `main` when appropriate (e.g., version-independent fixes that should not wait until the next GA).
 
 ### Contribution Workflow
 
@@ -130,11 +128,8 @@ git clone https://github.com/YOUR-USERNAME/rhdh-local.git && cd rhdh-local
 # Add upstream remote for staying current
 git remote add upstream https://github.com/redhat-developer/rhdh-local.git
 
-# Create a branch from the correct base (see "Which branch should my PR target?" above)
-# For next-release work:
+# Create a branch from dev (see "Which branch should my PR target?" above)
 git checkout -b feature/my-contribution upstream/dev
-# For version-independent changes:
-git checkout -b fix/my-fix upstream/main
 ```
 
 #### 2. Development Guidelines

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "baseBranches": [
+    "dev"
   ]
 }


### PR DESCRIPTION
## Target branch

- [x] I have verified this PR targets the correct branch (see [branching strategy](https://github.com/redhat-developer/rhdh-local/blob/HEAD/docs/rhdh-local-guide/help-and-contrib.md#branching-model))

## Description

Documents the `main`/`dev` branching model adopted in [ADR 007](https://github.com/redhat-developer/rhdh-adr/blob/main/decisions/007-rhdh-local-branching-strategy.md):

- **README.md**: added branching model summary to the Contributing section
- **docs/rhdh-local-guide/help-and-contrib.md**: added "Branching Model" subsection with PR targeting tables; updated contribution workflow to branch from the correct upstream base (`upstream/dev` or `upstream/main`)
- **.github/PULL_REQUEST_TEMPLATE.md**: added "Target branch" section with a verification checkbox
- **.github/workflows/test.yml**: added `dev` to push/pull_request branch triggers

## Which issue(s) does this PR fix or relate to

- Related to [ADR 007 - Branching strategy for rhdh-local development](https://github.com/redhat-developer/rhdh-adr/blob/main/decisions/007-rhdh-local-branching-strategy.md)

## PR acceptance criteria

- [x] Tests updated and passing
- [x] Documentation updated
- [x] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

## How to test changes / Special notes to the reviewer

- Verify TechDocs render correctly in RHDH Local (restart container and check the Help & Contributing page)
- Verify PR template renders correctly when opening a new PR
- Verify CI triggers on PRs targeting `dev`