### PR TITLE
[main] chore: tagRelease.sh: bump to 1.10.3

### DIFF
--- a/default.env
+++ b/default.env
@@ -14,7 +14,7 @@ BASE_URL=http://localhost:7007
 # Default plugin catalog index image
 # Requires RHDH 1.9+ to be handled.
 # TODO: Pinned due to issues with the floating 1.10 tag - see RHDHBUGS-3455 and RHDHBUGS-3492
-CATALOG_INDEX_IMAGE=quay.io/rhdh/plugin-catalog-index:1.10.2
+CATALOG_INDEX_IMAGE=quay.io/rhdh/plugin-catalog-index:1.10.3
 
 # Extra catalog index images (comma-separated).
 # Plugins from these images appear in the Extensions UI but are not installed by default.

--- a/docs/rhdh-local-guide/container-image-guide.md
+++ b/docs/rhdh-local-guide/container-image-guide.md
@@ -51,7 +51,7 @@ To use the [official release of RHDH](https://catalog.redhat.com/software/contai
 NOTE: Using official builds also [requires authentication with the registry](https://access.redhat.com/articles/RegistryAuthentication). See also the section below `Configuring registry credentials` to make this authentication pervasive.
 
 ```sh
-RHDH_IMAGE=registry.redhat.io/rhdh/rhdh-hub-rhel9:1.9
+RHDH_IMAGE=registry.redhat.io/rhdh/rhdh-hub-rhel9:1.10.3
 ```
 
 #### Using image digests


### PR DESCRIPTION
Manual cherry-pick of https://github.com/redhat-developer/rhdh-local/pull/281