### PR TITLE
fix: update plugins in default configuration based on the content of the `next` DPDY

### DIFF
--- a/.github/actions/rhdh-local-compose-test/action.yaml
+++ b/.github/actions/rhdh-local-compose-test/action.yaml
@@ -222,6 +222,14 @@ runs:
         cat <<EOF > configs/dynamic-plugins/dynamic-plugins.override.yaml
         includes: [dynamic-plugins.default.yaml]
         plugins:
+        # This is just to enable the /api/extensions endpoint, which is used in CI to validate the plugins list.
+        # TODO: we may need to update this ref
+        - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-extensions-backend:bs_1.52.0__0.19.1'
+          disabled: false
+          pluginConfig:
+            extensions:
+              installation:
+                enabled: false
         - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic
           disabled: false
         - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,8 +46,10 @@ jobs:
             cliArgs: "-f compose.yaml -f compose-with-corporate-proxy.yaml"
           - name: "dynamic-plugins-root"
             cliArgs: "-f compose.yaml -f compose-dynamic-plugins-root.yaml"
-          - name: "orchestrator-workflow"
-            cliArgs: "-f compose.yaml -f orchestrator/compose.yaml"
+# TODO: re-enable this test once we can use the right references.
+# Tracked in https://redhat.atlassian.net/browse/RHDHBUGS-3559
+#          - name: "orchestrator-workflow"
+#            cliArgs: "-f compose.yaml -f orchestrator/compose.yaml"
 
     name: "${{ matrix.tool }} compose - ${{ matrix.composeConfig.name }}${{ matrix.os != 'ubuntu-24.04' && format(' - {0}', matrix.os) || '' }}${{ matrix.userConfig == 'true' && ' - user config' || '' }}"
     runs-on: ${{ matrix.os }}

--- a/configs/app-config/app-config.yaml
+++ b/configs/app-config/app-config.yaml
@@ -271,7 +271,7 @@ proxy:
 
 quay:
   # The UI url for Quay, used to generate the link to Quay
-  uiUrl: "https://quay.io"
+  apiUrl: "https://quay.io"
 
 # ==============================================================================
 # Developer Lightspeed Plugin Configuration

--- a/configs/dynamic-plugins/dynamic-plugins.yaml
+++ b/configs/dynamic-plugins/dynamic-plugins.yaml
@@ -6,37 +6,27 @@ includes:
 
 plugins:
   # Tech Radar frontend plugin
-# # TODO: Replace the `./dynamic-plugins/dist/` path with the OCI reference once we switch to that in the dynamic-plugins.default.yaml (DPDY) file in the catalog index image - see https://issues.redhat.com/browse/RHDHPLAN-934 and https://issues.redhat.com/browse/RHDHPLAN-256
-  # - package: 'oci://quay.io/rhdh/backstage-community-plugin-tech-radar:{{inherit}}'
-  - package: ./dynamic-plugins/dist/backstage-community-plugin-tech-radar
+  - package: 'oci://quay.io/rhdh/backstage-community-plugin-tech-radar:{{inherit}}'
     disabled: false
 
   # Quay plugin
-  - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay-backend:{{inherit}}'
+  - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay-backend:bs_1.52.0__1.17.0'
     disabled: false
 
   # Scaffolder Github plugin - used by Dynamic Plugin Software Templates
-  - package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic
+  - package: 'oci://quay.io/rhdh/backstage-plugin-scaffolder-backend-module-github:{{inherit}}'
     disabled: false
-
-  # Floating Action Button plugin with submenu actions
-  # TODO: This plugin will be removed in RHDH 2.1 (https://redhat.atlassian.net/browse/RHDHPLAN-1006)
-  # - package: 'oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-global-floating-action-button:{{inherit}}'
-  - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-global-floating-action-button
-    disabled: true # disabled as conflicts with Lightspeed FAB, will be deprecated / removed.
 
   #########################################################
   # Enable dynamic plugins installation by using Extensions
   #########################################################
 
-  # TODO: Replace the `./dynamic-plugins/dist/` path with the OCI reference once we switch to that in the dynamic-plugins.default.yaml (DPDY) file in the catalog index image - see https://issues.redhat.com/browse/RHDHPLAN-934 and https://issues.redhat.com/browse/RHDHPLAN-256
-  # - package: 'oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-extensions:{{inherit}}'
-  - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions
+  # TODO: we may need to update this ref
+  - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-extensions:bs_1.52.0__0.19.1'
     disabled: false
 
-  # TODO: Replace the `./dynamic-plugins/dist/` path with the OCI reference once we switch to that in the dynamic-plugins.default.yaml (DPDY) file in the catalog index image - see https://issues.redhat.com/browse/RHDHPLAN-934 and https://issues.redhat.com/browse/RHDHPLAN-256
-  # - package: 'oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-extensions-backend:{{inherit}}'
-  - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions-backend-dynamic
+  # TODO: we may need to update this ref
+  - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-extensions-backend:bs_1.52.0__0.19.1'
     disabled: false
     pluginConfig:
       extensions:
@@ -52,9 +42,11 @@ plugins:
   #########################################################
 
   # Lightspeed frontend plugin
+  # TODO: re-enable this once the catalog index is stabilized
   - package: 'oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed:{{inherit}}'
-    disabled: false
+    disabled: true
 
   # Lightspeed backend plugin
+  # TODO: re-enable this once the catalog index is stabilized
   - package: 'oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed-backend:{{inherit}}'
-    disabled: false
+    disabled: true


### PR DESCRIPTION
## Target branch

<!--
This repository uses a main/dev branching model. Please confirm that
your PR targets the correct branch:

- `dev`: all development work (features, docs, dependency updates, etc.)
- `release-x.y`: bug fixes for a specific supported release

Do not target `main` directly; maintainers manage it via merges and cherry-picks.
-->

- [x] I have verified this PR targets the correct branch (see [branching strategy](https://github.com/redhat-developer/rhdh-local/blob/HEAD/docs/rhdh-local-guide/help-and-contrib.md#branching-model))

## Description
Update plugin references in default configuration, matching what's available in the `next` catalog index image.

## Which issue(s) does this PR fix or relate to

&mdash;

## PR acceptance criteria

- [ ] Tests updated and passing
- [ ] Documentation updated
- [ ] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
