### PR TITLE
ci: add workflow to warn PRs targeting main

### DIFF
--- a/.github/workflows/branch-target-check.yaml
+++ b/.github/workflows/branch-target-check.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Check for existing warning comment
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const marker = '<!-- branch-target-check -->';
@@ -28,7 +28,7 @@ jobs:
 
       - name: Post warning comment
         if: steps.check.outputs.result != 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const marker = '<!-- branch-target-check -->';

--- a/.github/workflows/branch-target-check.yaml
+++ b/.github/workflows/branch-target-check.yaml
@@ -1,0 +1,55 @@
+name: Branch Target Check
+
+on:
+  pull_request_target:
+    types: [opened, edited]
+    branches: [main]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  warn-main-target:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for existing warning comment
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- branch-target-check -->';
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+            const existing = comments.data.find(c => c.body.includes(marker));
+            return !!existing;
+
+      - name: Post warning comment
+        if: steps.check.outputs.result != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- branch-target-check -->';
+            const body = [
+              marker,
+              '> [!WARNING]',
+              '> **This PR targets `main`.** This repository uses a `main`/`dev` branching model.',
+              '>',
+              '> - All development work (features, docs, dependency updates) should target **`dev`**.',
+              '> - Bug fixes for a supported release should target **`release-x.y`**.',
+              '> - Only maintainer-managed merges and cherry-picks should go into `main`.',
+              '>',
+              '> If this is intentional (e.g., a backport or maintainer merge), you can ignore this message.',
+              '> Otherwise, please retarget your PR to `dev`.',
+              '>',
+              '> See the [branching strategy](https://github.com/redhat-developer/rhdh-local/blob/HEAD/docs/rhdh-local-guide/help-and-contrib.md#branching-model) for details.',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body,
+            });


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that posts a warning comment when a PR is opened against `main`, reminding contributors to target `dev` per the branching strategy
- Warning-only — no checks fail — so legitimate cases like backports and maintainer merges are not blocked
- Uses a hidden HTML marker to avoid posting duplicate comments if the PR is edited

## Test plan
- [ ] Open a test PR targeting `main` and verify the warning comment appears
- [ ] Edit the same PR and verify no duplicate comment is posted
- [ ] Open a PR targeting `dev` and verify no comment is posted