### PR TITLE
[Release-1.10] chore: update lcore image from 0.5.3 to 0.6.2

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -98,7 +98,7 @@ services:
   # Default image: quay.io/lightspeed-core/lightspeed-stack:0.5.1
   # To override: Set LIGHTSPEED_CORE_IMAGE in your .env file
   lightspeed-core:
-    image: ${LIGHTSPEED_CORE_IMAGE:-quay.io/lightspeed-core/lightspeed-stack:0.5.3} # dclint disable-line service-image-require-explicit-tag
+    image: ${LIGHTSPEED_CORE_IMAGE:-quay.io/lightspeed-core/lightspeed-stack:0.6.2} # dclint disable-line service-image-require-explicit-tag
     container_name: lightspeed-core
     network_mode: "service:rhdh"
     depends_on:


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Target branch

<!--
This repository uses a main/dev branching model. Please confirm that
your PR targets the correct branch:

- `dev`: all development work (features, docs, dependency updates, etc.)
- `release-x.y`: bug fixes for a specific supported release

Do not target `main` directly; maintainers manage it via merges and cherry-picks.
-->

- [x] I have verified this PR targets the correct branch (see [branching strategy](https://github.com/redhat-developer/rhdh-local/blob/HEAD/docs/rhdh-local-guide/help-and-contrib.md#branching-model))

## Description
<!--
Please explain the changes you made here.
-->
- Bumps LCORE image from `0.5.3` to `0.6.2` for RHDH `1.10.4` release as `0.5.x` is going EOL
## Which issue(s) does this PR fix or relate to

https://redhat.atlassian.net/browse/RHIDP-16122

## PR acceptance criteria

- [ ] Tests updated and passing
- [ ] Documentation updated
- [ ] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
