### PR TITLE
fix: update default dynamic plugins config and fix CI [RHDHBUGS-3687]

### DIFF
--- a/.github/actions/rhdh-local-compose-test/action.yaml
+++ b/.github/actions/rhdh-local-compose-test/action.yaml
@@ -231,9 +231,9 @@ runs:
         cat <<EOF > /tmp/ci-plugins-override.yaml
         plugins:
         - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic
-          disabled: false
+          enabled: true
         - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import
-          disabled: false
+          enabled: true
         EOF
         yq -i '.plugins += load("/tmp/ci-plugins-override.yaml").plugins' configs/dynamic-plugins/dynamic-plugins.override.yaml
 

--- a/.github/actions/rhdh-local-compose-test/action.yaml
+++ b/.github/actions/rhdh-local-compose-test/action.yaml
@@ -219,22 +219,23 @@ runs:
         EOF
 
         # Custom dynamic-plugins.override.yaml
-        cat <<EOF > configs/dynamic-plugins/dynamic-plugins.override.yaml
-        includes: [dynamic-plugins.default.yaml]
+        # Start from the default config so all baseline plugins are included,
+        # then merge in CI-specific overrides.
+        cp configs/dynamic-plugins/dynamic-plugins.yaml configs/dynamic-plugins/dynamic-plugins.override.yaml
+
+        # Override the extensions-backend entry to disable installation in CI
+        yq -i '(.plugins[] | select(.package | test("extensions-backend-dynamic")) | .pluginConfig.extensions.installation.enabled) = false' \
+          configs/dynamic-plugins/dynamic-plugins.override.yaml
+
+        # Append CI-specific plugins
+        cat <<EOF > /tmp/ci-plugins-override.yaml
         plugins:
-        # This is just to enable the /api/extensions endpoint, which is used in CI to validate the plugins list.
-        # TODO: we may need to update this ref
-        - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-extensions-backend:bs_1.52.0__0.19.1'
-          disabled: false
-          pluginConfig:
-            extensions:
-              installation:
-                enabled: false
         - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic
           disabled: false
         - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import
           disabled: false
         EOF
+        yq -i '.plugins += load("/tmp/ci-plugins-override.yaml").plugins' configs/dynamic-plugins/dynamic-plugins.override.yaml
 
         # Custom extra files
         cp -vr configs/extra-files/github-app-credentials.example.yaml configs/extra-files/github-app-credentials.yaml

--- a/configs/dynamic-plugins/dynamic-plugins.override.example.yaml
+++ b/configs/dynamic-plugins/dynamic-plugins.override.example.yaml
@@ -98,15 +98,11 @@ includes:
 #                 importName: RbacPage
 
 # # Uncomment the following two plugins to enable dynamic plugins installation via the Extensions UI
-# # TODO: Replace the `./dynamic-plugins/dist/` path with the OCI reference once we switch to that in the dynamic-plugins.default.yaml (DPDY) file in the catalog index image - see https://issues.redhat.com/browse/RHDHPLAN-934 and https://issues.redhat.com/browse/RHDHPLAN-256
-# # - package: 'oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-extensions:{{inherit}}'
-# - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions
-#   disabled: false
+# - package: 'ref://red-hat-developer-hub-backstage-plugin-extensions'
+#   enabled: true
 
-# # TODO: Replace the `./dynamic-plugins/dist/` path with the OCI reference once we switch to that in the dynamic-plugins.default.yaml (DPDY) file in the catalog index image - see https://issues.redhat.com/browse/RHDHPLAN-934 and https://issues.redhat.com/browse/RHDHPLAN-256
-# # - package: 'oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-extensions-backend:{{inherit}}'
-# - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions-backend-dynamic
-#   disabled: false
+# - package: 'ref://red-hat-developer-hub-backstage-plugin-extensions-backend-dynamic'
+#   enabled: true
 #   pluginConfig:
 #     extensions:
 #       installation:

--- a/configs/dynamic-plugins/dynamic-plugins.yaml
+++ b/configs/dynamic-plugins/dynamic-plugins.yaml
@@ -5,6 +5,12 @@ includes:
   - /dynamic-plugins-root/dynamic-plugins.extensions.yaml
 
 plugins:
+  # Guest auth backend module — RHDH 2+ no longer bundles auth provider plugins statically (https://redhat.atlassian.net/browse/RHIDP-15348).
+  # These will be available dynamic plugins (https://redhat.atlassian.net/browse/RHIDP-16098)
+  # TODO: update this if/when it is listed in the DPDY. Remove this if it comes enabled by default in the DPDY.
+  - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-auth-backend-module-guest-provider:bs_1.52.0__0.2.20'
+    disabled: false
+
   # Tech Radar frontend plugin
   - package: 'oci://quay.io/rhdh/backstage-community-plugin-tech-radar:{{inherit}}'
     disabled: false

--- a/configs/dynamic-plugins/dynamic-plugins.yaml
+++ b/configs/dynamic-plugins/dynamic-plugins.yaml
@@ -9,18 +9,18 @@ plugins:
   # These will be available as dynamic plugins (https://redhat.atlassian.net/browse/RHIDP-16098)
   # TODO: update this if/when it is listed in the DPDY. Remove this if it comes enabled by default in the DPDY.
   - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-auth-backend-module-guest-provider:bs_1.52.0__0.2.20'
-    disabled: false
+    enabled: true
 
   # Tech Radar frontend plugin
   - package: 'oci://quay.io/rhdh/backstage-community-plugin-tech-radar:{{inherit}}'
-    disabled: false
+    enabled: true
 
   # Quay plugins
   - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay-backend:bs_1.52.0__1.17.0'
-    disabled: false
-  
+    enabled: true
+
   - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay:bs_1.52.0__1.37.1'
-    disabled: false
+    enabled: true
     pluginConfig:
       dynamicPlugins:
         frontend:
@@ -37,19 +37,17 @@ plugins:
 
   # Scaffolder Github plugin - used by Dynamic Plugin Software Templates
   - package: 'oci://quay.io/rhdh/backstage-plugin-scaffolder-backend-module-github:{{inherit}}'
-    disabled: false
+    enabled: true
 
   #########################################################
   # Enable dynamic plugins installation by using Extensions
   #########################################################
 
-  # TODO: update this ref once the OCI plugin ref is available in the DPDY
-  - package: './dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions'
-    disabled: false
+  - package: 'ref://red-hat-developer-hub-backstage-plugin-extensions'
+    enabled: true
 
-  # TODO: update this ref once the OCI plugin ref is available in the DPDY
-  - package: './dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions-backend-dynamic'
-    disabled: false
+  - package: 'ref://red-hat-developer-hub-backstage-plugin-extensions-backend-dynamic'
+    enabled: true
     pluginConfig:
       extensions:
         installation:
@@ -66,9 +64,9 @@ plugins:
   # Lightspeed frontend plugin
   # TODO: re-enable this once the catalog index is stabilized
   - package: 'oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed:{{inherit}}'
-    disabled: true
+    enabled: false
 
   # Lightspeed backend plugin
   # TODO: re-enable this once the catalog index is stabilized
   - package: 'oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed-backend:{{inherit}}'
-    disabled: true
+    enabled: false

--- a/configs/dynamic-plugins/dynamic-plugins.yaml
+++ b/configs/dynamic-plugins/dynamic-plugins.yaml
@@ -6,7 +6,7 @@ includes:
 
 plugins:
   # Guest auth backend module — RHDH 2+ no longer bundles auth provider plugins statically (https://redhat.atlassian.net/browse/RHIDP-15348).
-  # These will be available dynamic plugins (https://redhat.atlassian.net/browse/RHIDP-16098)
+  # These will be available as dynamic plugins (https://redhat.atlassian.net/browse/RHIDP-16098)
   # TODO: update this if/when it is listed in the DPDY. Remove this if it comes enabled by default in the DPDY.
   - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-auth-backend-module-guest-provider:bs_1.52.0__0.2.20'
     disabled: false

--- a/configs/dynamic-plugins/dynamic-plugins.yaml
+++ b/configs/dynamic-plugins/dynamic-plugins.yaml
@@ -21,12 +21,12 @@ plugins:
   # Enable dynamic plugins installation by using Extensions
   #########################################################
 
-  # TODO: we may need to update this ref
-  - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-extensions:bs_1.52.0__0.19.1'
+  # TODO: update this ref once the OCI plugin ref is available in the DPDY
+  - package: './dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions'
     disabled: false
 
-  # TODO: we may need to update this ref
-  - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-extensions-backend:bs_1.52.0__0.19.1'
+  # TODO: update this ref once the OCI plugin ref is available in the DPDY
+  - package: './dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions-backend-dynamic'
     disabled: false
     pluginConfig:
       extensions:

--- a/configs/dynamic-plugins/dynamic-plugins.yaml
+++ b/configs/dynamic-plugins/dynamic-plugins.yaml
@@ -15,9 +15,25 @@ plugins:
   - package: 'oci://quay.io/rhdh/backstage-community-plugin-tech-radar:{{inherit}}'
     disabled: false
 
-  # Quay plugin
+  # Quay plugins
   - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay-backend:bs_1.52.0__1.17.0'
     disabled: false
+  
+  - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay:bs_1.52.0__1.37.1'
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          backstage-community.plugin-quay:
+            mountPoints:
+              - mountPoint: entity.page.image-registry/cards
+                importName: QuayPage
+                config:
+                  layout:
+                    gridColumn: 1 / -1
+                  if:
+                    anyOf:
+                      - isQuayAvailable
 
   # Scaffolder Github plugin - used by Dynamic Plugin Software Templates
   - package: 'oci://quay.io/rhdh/backstage-plugin-scaffolder-backend-module-github:{{inherit}}'

--- a/tests/required-plugins.yaml
+++ b/tests/required-plugins.yaml
@@ -1,0 +1,16 @@
+# Baseline plugins that must always be loaded in RHDH Local,
+# regardless of the dynamic-plugins configuration.
+# Enforced by validate-loaded-plugins.sh.
+#
+# Ref: https://redhat.atlassian.net/browse/RHDHPLAN-573
+plugins:
+  - backstage-plugin-auth-backend-module-guest-provider
+  - backstage-community-plugin-tech-radar
+  - backstage-community-plugin-quay-backend
+  - backstage-community-plugin-quay
+  - backstage-plugin-scaffolder-backend-module-github
+  - red-hat-developer-hub-backstage-plugin-extensions
+  - red-hat-developer-hub-backstage-plugin-extensions-backend-dynamic
+  # TODO: re-enable once the catalog index is stabilized
+  # - red-hat-developer-hub-backstage-plugin-lightspeed
+  # - red-hat-developer-hub-backstage-plugin-lightspeed-backend

--- a/tests/validate-loaded-plugins.sh
+++ b/tests/validate-loaded-plugins.sh
@@ -11,6 +11,8 @@
 #
 # The script determines the effective dynamic-plugins config
 # (override if it exists, else default) and parses it using yq.
+# A baseline list from tests/required-plugins.yaml is merged in so
+# that removing a plugin from the config still triggers a failure.
 # Any extra config files (e.g., orchestrator) can be passed as arguments.
 # Assumes CWD is the repository root.
 
@@ -28,6 +30,7 @@ done
 
 RHDH_URL="${RHDH_URL:-http://localhost:7007}"
 DYN_PLUGINS_DIR="configs/dynamic-plugins"
+REQUIRED_PLUGINS_FILE="tests/required-plugins.yaml"
 
 primary_config="$DYN_PLUGINS_DIR/dynamic-plugins.yaml"
 if [[ -f "$DYN_PLUGINS_DIR/dynamic-plugins.override.yaml" ]]; then
@@ -72,8 +75,11 @@ normalize_plugin_name() {
     echo "$name"
 }
 
-expected_plugins=()
-disabled_plugins=()
+# Track plugin state with an associative array so later config files
+# (e.g. override) take precedence over earlier ones (e.g. default).
+declare -A plugin_state  # normalized_name → "enabled" | "disabled"
+declare -A plugin_display # normalized_name → raw display name
+
 for cfg in "${config_files[@]}"; do
     if ! yq -e '.plugins' "$cfg" > /dev/null 2>&1; then
         echo "Config $cfg has no .plugins array, skipping."
@@ -86,7 +92,10 @@ for cfg in "${config_files[@]}"; do
     }
     while IFS= read -r raw_pkg; do
         [[ -z "$raw_pkg" ]] && continue
-        expected_plugins+=("$(extract_plugin_name "$raw_pkg")")
+        name=$(extract_plugin_name "$raw_pkg")
+        norm=$(normalize_plugin_name "$name")
+        plugin_state["$norm"]="enabled"
+        plugin_display["$norm"]="$name"
     done <<< "$enabled_output"
 
     disabled_output=$(yq -r '.plugins[] | select(.disabled == true or .enabled == false) | .package' "$cfg") || {
@@ -95,9 +104,46 @@ for cfg in "${config_files[@]}"; do
     }
     while IFS= read -r raw_pkg; do
         [[ -z "$raw_pkg" ]] && continue
-        disabled_plugins+=("$(extract_plugin_name "$raw_pkg")")
+        name=$(extract_plugin_name "$raw_pkg")
+        norm=$(normalize_plugin_name "$name")
+        plugin_state["$norm"]="disabled"
+        plugin_display["$norm"]="$name"
     done <<< "$disabled_output"
 done
+
+# Build final lists from the resolved state.
+expected_plugins=()
+disabled_plugins=()
+for norm in "${!plugin_state[@]}"; do
+    if [[ "${plugin_state[$norm]}" = "enabled" ]]; then
+        expected_plugins+=("${plugin_display[$norm]}")
+    else
+        disabled_plugins+=("${plugin_display[$norm]}")
+    fi
+done
+
+# Merge baseline required plugins (deduplicated) into the expected list.
+if [[ -f "$REQUIRED_PLUGINS_FILE" ]]; then
+    echo "Required plugins file: $REQUIRED_PLUGINS_FILE"
+    required_output=$(yq -r '.plugins[]' "$REQUIRED_PLUGINS_FILE" 2>/dev/null) || true
+    while IFS= read -r req_plugin; do
+        [[ -z "$req_plugin" ]] && continue
+        norm_req=$(normalize_plugin_name "$req_plugin")
+        already_listed=false
+        for existing in "${expected_plugins[@]}"; do
+            if [[ "$(normalize_plugin_name "$existing")" = "$norm_req" ]]; then
+                already_listed=true
+                break
+            fi
+        done
+        if ! $already_listed; then
+            expected_plugins+=("$req_plugin")
+            echo "  Adding baseline plugin: $req_plugin"
+        fi
+    done <<< "$required_output"
+else
+    echo "WARNING: Required plugins file not found: $REQUIRED_PLUGINS_FILE"
+fi
 
 if [[ ${#expected_plugins[@]} -eq 0 ]] && [[ ${#disabled_plugins[@]} -eq 0 ]]; then
     echo "WARNING: No plugins found in config files. Nothing to validate."


### PR DESCRIPTION
## Description

Fixes RHDH Local not starting in the `dev` branch - CI also failing on all PRs.

- **Add guest auth backend module as a dynamic plugin.** RHDH 2+ ([rhdh#5258](https://github.com/redhat-developer/rhdh/pull/5258) / [RHIDP-15348](https://redhat.atlassian.net/browse/RHIDP-15348)) removed statically-wired auth provider modules from the backend. Guest login was broken because `/api/auth/guest/refresh` returned 404. Once these are available as OOTB dynamic plugins ([RHIDP-16098](https://redhat.atlassian.net/browse/RHIDP-16098)), this entry can be updated or removed.
- **Fix extensions plugin refs.** based on what's available in the DPDY/RHDH image at this time.

## Which issue(s) does this PR fix or relate to

- Fixes [RHDHBUGS-3687](https://redhat.atlassian.net/browse/RHDHBUGS-3687)

## PR acceptance criteria

- [ ] Tests updated and passing
- [ ] Documentation updated
- [ ] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

## How to test changes / Special notes to the reviewer

1. `podman compose down && podman compose up -d`
2. Open http://localhost:7007 and verify guest login works
3. Check container logs — `/api/auth/guest/refresh` should return 200 instead of 404
4. Verify the Extensions catalog is accessible at `/extensions/catalog`