### PR TITLE
fix: migrate extensions plugins from local dist to OCI after rhdh#5299

### DIFF
--- a/.github/actions/rhdh-local-compose-test/action.yaml
+++ b/.github/actions/rhdh-local-compose-test/action.yaml
@@ -223,16 +223,16 @@ runs:
         # then merge in CI-specific overrides.
         cp configs/dynamic-plugins/dynamic-plugins.yaml configs/dynamic-plugins/dynamic-plugins.override.yaml
 
-        # Override the extensions-backend entry to disable installation in CI
-        yq -i '(.plugins[] | select(.package | test("extensions-backend-dynamic")) | .pluginConfig.extensions.installation.enabled) = false' \
+        # Override the extensions backend entry to disable installation in CI
+        yq -i '(.plugins[] | select(.package | test("extensions-backend")) | .pluginConfig.extensions.installation.enabled) = false' \
           configs/dynamic-plugins/dynamic-plugins.override.yaml
 
         # Append CI-specific plugins
         cat <<EOF > /tmp/ci-plugins-override.yaml
         plugins:
-        - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic
+        - package: ref://red-hat-developer-hub-backstage-plugin-bulk-import-backend
           enabled: true
-        - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import
+        - package: ref://red-hat-developer-hub-backstage-plugin-bulk-import
           enabled: true
         EOF
         yq -i '.plugins += load("/tmp/ci-plugins-override.yaml").plugins' configs/dynamic-plugins/dynamic-plugins.override.yaml

--- a/compose-dynamic-plugins-root.yaml
+++ b/compose-dynamic-plugins-root.yaml
@@ -13,4 +13,4 @@ services:
 
   install-dynamic-plugins:
     volumes:
-      - ./dynamic-plugins-root:/dynamic-plugins-root
+      - ./dynamic-plugins-root:/opt/app-root/src/dynamic-plugins-root

--- a/compose.yaml
+++ b/compose.yaml
@@ -70,7 +70,7 @@ services:
       - ./prepare-and-install-dynamic-plugins.sh:/opt/app-root/src/prepare-and-install-dynamic-plugins.sh:Z
       - ./local-plugins:/opt/app-root/src/local-plugins:Z
       - ./configs:/opt/app-root/src/configs:z
-      - dynamic-plugins-root:/dynamic-plugins-root
+      - dynamic-plugins-root:/opt/app-root/src/dynamic-plugins-root
       - extensions-catalog:${CATALOG_ENTITIES_EXTRACT_DIR:-/extensions}
 
   # RAG initialization service: Copies RAG embeddings and vector database to shared volumes

--- a/configs/dynamic-plugins/dynamic-plugins.override.example.yaml
+++ b/configs/dynamic-plugins/dynamic-plugins.override.example.yaml
@@ -13,12 +13,12 @@ includes:
 # plugins: 
 # Functioning example using Tech Radar, uncomment to use
   #Tech Radar frontend plugin
-  # - package: ./dynamic-plugins/dist/backstage-community-plugin-tech-radar
+  # - package: ref://backstage-community-plugin-tech-radar
   #   enabled: true
 
   # Tech Radar backend plugin. Required if you want to customize the tech radar URL 
   # (see the `techRadar.url` app-config property).
-  # - package: ./dynamic-plugins/dist/backstage-community-plugin-tech-radar-backend-dynamic
+  # - package: ref://backstage-community-plugin-tech-radar-backend
   #   enabled: true
 
 # # loading plugin from host directory
@@ -75,8 +75,8 @@ includes:
 #               cadence: '*/15 * * * *'
 #       lifecycle: { timeToLive: { weeks: 2 } }
 
-# # loading plugin from directory inside the RHDH container
-#   - package: ./dynamic-plugins/dist/backstage-community-plugin-rbac
+# # loading plugin from the catalog index
+#   - package: ref://backstage-community-plugin-rbac
 #     enabled: false
 #     pluginConfig:
 #       dynamicPlugins:
@@ -98,10 +98,10 @@ includes:
 #                 importName: RbacPage
 
 # # Uncomment the following two plugins to enable dynamic plugins installation via the Extensions UI
-# - package: 'ref://red-hat-developer-hub-backstage-plugin-extensions'
+# - package: 'oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-extensions:2.0.0--0.19.1!red-hat-developer-hub-backstage-plugin-extensions'
 #   enabled: true
 
-# - package: 'ref://red-hat-developer-hub-backstage-plugin-extensions-backend-dynamic'
+# - package: 'oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-extensions-backend:2.0.0--0.19.1!red-hat-developer-hub-backstage-plugin-extensions-backend'
 #   enabled: true
 #   pluginConfig:
 #     extensions:

--- a/configs/dynamic-plugins/dynamic-plugins.override.example.yaml
+++ b/configs/dynamic-plugins/dynamic-plugins.override.example.yaml
@@ -5,7 +5,7 @@ includes:
   - dynamic-plugins.default.yaml
   # Uncomment the following line (and the corresponding 'red-hat-developer-hub-backstage-plugin-extensions*' plugins)
   # to enable dynamic plugins installation using the Extensions UI.
-  # - /dynamic-plugins-root/dynamic-plugins.extensions.yaml
+  # - /opt/app-root/src/dynamic-plugins-root/dynamic-plugins.extensions.yaml
 
 # # Below you can add custom dynamic plugins, including local ones.
 

--- a/configs/dynamic-plugins/dynamic-plugins.yaml
+++ b/configs/dynamic-plugins/dynamic-plugins.yaml
@@ -2,7 +2,7 @@
 includes:
   - dynamic-plugins.default.yaml
   # Writable path in the init container for extensions plugin configuration.
-  - /dynamic-plugins-root/dynamic-plugins.extensions.yaml
+  - /opt/app-root/src/dynamic-plugins-root/dynamic-plugins.extensions.yaml
 
 plugins:
   # Guest auth backend module — RHDH 2+ no longer bundles auth provider plugins statically (https://redhat.atlassian.net/browse/RHIDP-15348).

--- a/configs/dynamic-plugins/dynamic-plugins.yaml
+++ b/configs/dynamic-plugins/dynamic-plugins.yaml
@@ -43,10 +43,28 @@ plugins:
   # Enable dynamic plugins installation by using Extensions
   #########################################################
 
-  - package: 'ref://red-hat-developer-hub-backstage-plugin-extensions'
+  # RHDH no longer embeds these plugin wrappers in dynamic-plugins/dist.
+  # Disable the obsolete catalog entries so they are omitted from generated
+  # configuration, then replace them with the OCI artifacts.
+  - package: './dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-catalog-backend-module-extensions-dynamic'
+    enabled: false
+
+  - package: './dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions'
+    enabled: false
+
+  - package: './dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions-backend-dynamic'
+    enabled: false
+
+  - package: 'oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-catalog-backend-module-extensions:2.0.0--0.19.1!red-hat-developer-hub-backstage-plugin-catalog-backend-module-extensions'
+    enabled: true
+    pluginConfig:
+      extensions:
+        directory: ${RHDH_EXTENSIONS_DIRECTORY}
+
+  - package: 'oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-extensions:2.0.0--0.19.1!red-hat-developer-hub-backstage-plugin-extensions'
     enabled: true
 
-  - package: 'ref://red-hat-developer-hub-backstage-plugin-extensions-backend-dynamic'
+  - package: 'oci://quay.io/rhdh/red-hat-developer-hub-backstage-plugin-extensions-backend:2.0.0--0.19.1!red-hat-developer-hub-backstage-plugin-extensions-backend'
     enabled: true
     pluginConfig:
       extensions:

--- a/configs/dynamic-plugins/dynamic-plugins.yaml
+++ b/configs/dynamic-plugins/dynamic-plugins.yaml
@@ -46,6 +46,7 @@ plugins:
   # RHDH no longer embeds these plugin wrappers in dynamic-plugins/dist.
   # Disable the obsolete catalog entries so they are omitted from generated
   # configuration, then replace them with the OCI artifacts.
+  # Remove once RHDHBUGS-3710 is resolved.
   - package: './dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-catalog-backend-module-extensions-dynamic'
     enabled: false
 

--- a/prepare-and-install-dynamic-plugins.sh
+++ b/prepare-and-install-dynamic-plugins.sh
@@ -16,8 +16,8 @@ if [ -d "dynamic-plugins-root" ]; then
     echo "dynamic-plugins-root exists"
     if [ ! -f "dynamic-plugins-root/app-config.dynamic-plugins.yaml" ]; then
         echo "app-config.dynamic-plugins.yaml does not exist"
-        echo "Removing dynamic-plugins-root to fix RHIDP-3939"
-        rm -rf ./dynamic-plugins-root
+        echo "Clearing dynamic-plugins-root contents to fix RHIDP-3939"
+        rm -rf ./dynamic-plugins-root/* ./dynamic-plugins-root/.* 2>/dev/null || true
     fi
 fi
 
@@ -51,7 +51,8 @@ else
     echo "No .npmrc found, skipping NPM_CONFIG_USERCONFIG"
 fi
 
-DYNAMIC_PLUGINS_EXTENSIONS_FILE="/dynamic-plugins-root/dynamic-plugins.extensions.yaml"
+DYNAMIC_PLUGINS_ROOT="/opt/app-root/src/dynamic-plugins-root"
+DYNAMIC_PLUGINS_EXTENSIONS_FILE="$DYNAMIC_PLUGINS_ROOT/dynamic-plugins.extensions.yaml"
 if [ ! -f "$DYNAMIC_PLUGINS_EXTENSIONS_FILE" ]; then
     echo "$DYNAMIC_PLUGINS_EXTENSIONS_FILE does not exist - creating it to enable dynamic plugins installation by using Extensions..."
     cat <<EOF > "$DYNAMIC_PLUGINS_EXTENSIONS_FILE"
@@ -60,11 +61,9 @@ includes:
 
 plugins: []
 EOF
-    # The file needs to be writable by the main RHDH container user.
-    # Otherwise, the extensions backend plugin will not be able to save the dynamic plugins configuration
     chown 1001 "$DYNAMIC_PLUGINS_EXTENSIONS_FILE"
     echo '... file '$DYNAMIC_PLUGINS_EXTENSIONS_FILE' created!'
 fi
 
 echo "Running install-dynamic-plugins.sh"
-./install-dynamic-plugins.sh /dynamic-plugins-root
+./install-dynamic-plugins.sh "$DYNAMIC_PLUGINS_ROOT"

--- a/tests/required-plugins.yaml
+++ b/tests/required-plugins.yaml
@@ -9,6 +9,7 @@ plugins:
   - backstage-community-plugin-quay-backend
   - backstage-community-plugin-quay
   - backstage-plugin-scaffolder-backend-module-github
+  - red-hat-developer-hub-backstage-plugin-catalog-backend-module-extensions
   - red-hat-developer-hub-backstage-plugin-extensions
   - red-hat-developer-hub-backstage-plugin-extensions-backend-dynamic
   # TODO: re-enable once the catalog index is stabilized

--- a/tests/validate-loaded-plugins.sh
+++ b/tests/validate-loaded-plugins.sh
@@ -49,7 +49,7 @@ done
 echo "Config files: ${config_files[*]}"
 
 # Extract the raw plugin name from a package reference.
-# ./dynamic-plugins/dist/foo → foo
+# ./local-plugins/foo → foo
 # oci://host/path/foo:tag → foo
 # oci://host/path/foo:tag!bar → bar
 extract_plugin_name() {
@@ -86,29 +86,20 @@ for cfg in "${config_files[@]}"; do
         continue
     fi
 
-    enabled_output=$(yq -r '.plugins[] | select(.disabled != true and .enabled != false) | .package' "$cfg") || {
-        echo "ERROR: Failed to extract enabled plugins from $cfg" >&2
+    # Process plugins in YAML order so later entries override earlier ones.
+    # This matters when a dist path is disabled and an OCI path for the same
+    # plugin is enabled — the OCI entry must win.
+    all_output=$(yq -o=json '.plugins' "$cfg" | jq -r '.[] | .package + "|" + (if (.disabled == true or .enabled == false) then "disabled" else "enabled" end)') || {
+        echo "ERROR: Failed to extract plugins from $cfg" >&2
         exit 1
     }
-    while IFS= read -r raw_pkg; do
+    while IFS='|' read -r raw_pkg state; do
         [[ -z "$raw_pkg" ]] && continue
         name=$(extract_plugin_name "$raw_pkg")
         norm=$(normalize_plugin_name "$name")
-        plugin_state["$norm"]="enabled"
+        plugin_state["$norm"]="$state"
         plugin_display["$norm"]="$name"
-    done <<< "$enabled_output"
-
-    disabled_output=$(yq -r '.plugins[] | select(.disabled == true or .enabled == false) | .package' "$cfg") || {
-        echo "ERROR: Failed to extract disabled plugins from $cfg" >&2
-        exit 1
-    }
-    while IFS= read -r raw_pkg; do
-        [[ -z "$raw_pkg" ]] && continue
-        name=$(extract_plugin_name "$raw_pkg")
-        norm=$(normalize_plugin_name "$name")
-        plugin_state["$norm"]="disabled"
-        plugin_display["$norm"]="$name"
-    done <<< "$disabled_output"
+    done <<< "$all_output"
 done
 
 # Build final lists from the resolved state.


### PR DESCRIPTION
## Summary

`rhdh#5299` removed the `dynamic-plugins/dist/` directory from the RHDH image, breaking all rhdh-local CI jobs. This PR migrates the extensions plugins to OCI artifacts and fixes the supporting infrastructure.

### Changes

**1. Replace local dist extensions with OCI references** (`86eb4a4`)
- Replace `./dynamic-plugins/dist/` extensions entries with OCI packages from `quay.io/rhdh/`
- Explicitly disable the obsolete default catalog index entries to prevent `pluginConfig` conflicts (the catalog index still ships `./dynamic-plugins/dist/` entries with `enabled: true` — see note below)
- Use correct OCI `!alias` names matching the actual directory names inside the OCI images (without `-dynamic` suffix)
- Update CI action and `required-plugins.yaml` baseline

**2. Align volume mount paths between init and main containers** (`af34697`)
- Mount `dynamic-plugins-root` at `/opt/app-root/src/dynamic-plugins-root` in both init and main containers (init previously used `/dynamic-plugins-root`)
- Update `prepare-and-install-dynamic-plugins.sh` to use the aligned path
- Fix RHIDP-3939 workaround to clear directory contents instead of removing the mount point (which fails with "Device or resource busy" when the path is the mount)
- Align `includes` path in `dynamic-plugins.yaml` and override example to match the new mount

**3. Fix validation script entry ordering** (`0dc9a18`)
- Process plugin entries in YAML order so later OCI `enabled: true` entries correctly override earlier `enabled: false` dist-path overrides for the same normalized plugin name
- Use `jq` for conditional logic (portable across `yq` versions)

### Note on `enabled: false` overrides

The `enabled: false` entries for `./dynamic-plugins/dist/` paths are a necessary workaround. The `next` catalog index still ships these entries as `enabled: true` with `pluginConfig` values. Without the overrides, the installer fails with `Config key 'extensions.installation.enabled' defined differently for 2 dynamic plugins`. These overrides can be removed once [RHDHBUGS-3710](https://issues.redhat.com/browse/RHDHBUGS-3710) is resolved.

### Related

- Upstream: https://github.com/redhat-developer/rhdh/pull/5299
- Blocked PR: https://github.com/redhat-developer/rhdh-local/pull/276
- Follow-up: [RHDHBUGS-3710](https://issues.redhat.com/browse/RHDHBUGS-3710) — Catalog index still ships dist-path entries for extensions plugins