### PR TITLE
chore(intelligent-assistant): change intelligent assistant (lightspeed) configs repository

### DIFF
--- a/.github/workflows/sync-lightspeed-configs.yaml
+++ b/.github/workflows/sync-lightspeed-configs.yaml
@@ -37,7 +37,12 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Sync Lightspeed config files
-        run: ./scripts/sync-lightspeed-configs.sh --ref ${{ matrix.branch }}
+        run: |
+          if [[ "${{ matrix.branch }}" == "release-1.10" ]]; then
+            ./scripts/sync-lightspeed-configs.sh --repo redhat-ai-dev/lightspeed-configs --ref ${{ matrix.branch }}
+          else
+            ./scripts/sync-lightspeed-configs.sh --ref ${{ matrix.branch }}
+          fi
 
       - name: Check for changes
         id: changes
@@ -58,6 +63,11 @@ jobs:
         run: |
           TITLE="chore(lightspeed): sync config files from upstream"
           BRANCH="chore/sync-lightspeed-configs-${TARGET_BRANCH}"
+          TARGET_REPO="redhat-developer/rhdh-intelligent-assistant-configs"
+          
+          if [[ "${TARGET_BRANCH}" == "release-1.10" ]]; then
+            TARGET_REPO="redhat-ai-dev/lightspeed-configs"
+          fi
 
           EXISTING_PR=$(gh pr list --head "${BRANCH}" --base "${TARGET_BRANCH}" --state open --json number --jq '.[0].number // empty')
 
@@ -77,7 +87,7 @@ jobs:
             git push origin "${BRANCH}"
 
             BODY=$(cat <<EOF
-          Automated nightly sync of Lightspeed config files from [redhat-ai-dev/lightspeed-configs](https://github.com/redhat-ai-dev/lightspeed-configs).
+          Automated nightly sync of Lightspeed config files from [${TARGET_REPO}](${TARGET_REPO}).
 
           ### Synced files
           - \`configs/extra-files/lightspeed-stack.yaml\`

--- a/docs/intelligent-assistant/maintaining-intelligent-assistant.md
+++ b/docs/intelligent-assistant/maintaining-intelligent-assistant.md
@@ -45,7 +45,7 @@ Developer Hub Intelligent Assistant runs as part of the default RHDH Local compo
 
 ## Syncing Lightspeed Configuration Files
 
-The Lightspeed Core configuration files (`rhdh-profile.py`, `lightspeed-stack.yaml`) are maintained upstream in the [redhat-ai-dev/lightspeed-configs](https://github.com/redhat-ai-dev/lightspeed-configs) repository. The sync script downloads them into `configs/extra-files/`.
+The Lightspeed Core configuration files (`rhdh-profile.py`, `lightspeed-stack.yaml`) are maintained upstream in the [redhat-developer/rhdh-intelligent-assistant-configs](https://github.com/redhat-developer/rhdh-intelligent-assistant-configs) repository. The sync script downloads them into `configs/extra-files/`.
 
 **Sync from default (main branch):**
 ```bash

--- a/scripts/sync-lightspeed-configs.sh
+++ b/scripts/sync-lightspeed-configs.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-DEFAULT_REPO="redhat-ai-dev/lightspeed-configs"
+DEFAULT_REPO="redhat-developer/rhdh-intelligent-assistant-configs"
 DEFAULT_REF="main"
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Target branch

- `dev`: all development work (features, docs, dependency updates, etc.)

- [X] I have verified this PR targets the correct branch (see [branching strategy](https://github.com/redhat-developer/rhdh-local/blob/HEAD/docs/rhdh-local-guide/help-and-contrib.md#branching-model))

## Description

We have migrated [redhat-ai-dev/lightspeed-configs](https://github.com/redhat-ai-dev/lightspeed-configs) to [redhat-developer/rhdh-intelligent-assistant-configs](https://github.com/redhat-developer/rhdh-intelligent-assistant-configs) for all upcoming feature releases of RHDH. Starting with RHDH 2.1, the intelligent assistant (lightspeed) configs will be fetched from [redhat-developer/rhdh-intelligent-assistant-configs](https://github.com/redhat-developer/rhdh-intelligent-assistant-configs).

**Note**: [redhat-ai-dev/lightspeed-configs](https://github.com/redhat-ai-dev/lightspeed-configs) will be kept active for RHDH 1.10 support, **do not backport this change**.

## Which issue(s) does this PR fix or relate to

~https://redhat.atlassian.net/browse/RHIDP-14891 **(Developer Week)**~

https://redhat.atlassian.net/browse/RHIDP-16898

## PR acceptance criteria

- [ ] Tests updated and passing
- [X] Documentation updated
- [ ] [Built-in TechDocs](https://github.com/redhat-developer/rhdh-local/tree/main/docs) updated if needed. Note that TechDocs changes may need to be reviewed by a Product Manager and/or Architect to ensure content accuracy, clarity, and alignment with user needs.

## How to test changes / Special notes to the reviewer

Run `bash hack/sync-lightspeed-configs.sh` to test syncing the content. Changes from this script are not part of this PR's scope however.
