### PR TITLE
docs: fix PostgreSQL guide database config indentation

### DIFF
--- a/docs/rhdh-local-guide/postgresql-guide.md
+++ b/docs/rhdh-local-guide/postgresql-guide.md
@@ -59,13 +59,14 @@ If you want to use PostgreSQL with RHDH, here are the steps:
 5. Add Postgres configuration in [`app-config.local.yaml`](https://github.com/redhat-developer/rhdh-local/blob/main/configs/app-config/app-config.local.example.yaml)
 
    ```yaml
-   database:
-    client: pg
-    connection:
-      host: ${POSTGRES_HOST}
-      port: ${POSTGRES_PORT}
-      user: ${POSTGRES_USER}
-      password: ${POSTGRES_PASSWORD}
+   backend:
+     database:
+       client: pg
+       connection:
+         host: ${POSTGRES_HOST}
+         port: ${POSTGRES_PORT}
+         user: ${POSTGRES_USER}
+         password: ${POSTGRES_PASSWORD}
    ```
 
    If you need **`pluginDivisionMode: schema`** (one database, one schema per plugin — useful when the DB user cannot create multiple databases), use this **`backend.database`** block in `app-config.local.yaml` **instead** of the snippet above:


### PR DESCRIPTION
## Summary
- Nest the PostgreSQL connection example in the guide under `backend.database` with correct YAML indentation.
- Aligns the snippet with Backstage's expected app-config structure.

See https://github.com/redhat-developer/rhdh-local/blob/main/docs/rhdh-local-guide/postgresql-guide.md

Made with [Cursor](https://cursor.com)